### PR TITLE
[Chore] #61 근무수첩 Request 변경 및 Swagger 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,17 @@ task swaggerConfig {
 
 		swaggerUIFile.append(securitySchemesContent)
 
+		def PostDiaryQueryContent =
+				"""
+      parameters:
+      - name: job
+        in: query
+        description: "[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"
+        required: true
+        schema:
+          type: string
+"""
+
 		def PostDiaryContent =
 				"""
       requestBody:
@@ -122,9 +133,6 @@ task swaggerConfig {
         imageUrlList:
           type: string
           description: "기존 이미지 URL 리스트 (or null)"
-        jobTitle:
-          type: string
-          description: "[필수] 직업명"
         rounding:
           type: number
           description: "[필수] 라운딩 수"
@@ -163,9 +171,6 @@ task swaggerConfig {
         imageUrlList:
           type: string
           description: "기존 이미지 URL 리스트 (or null)"
-        jobTitle:
-          type: string
-          description: "[필수] 직업명"
         numberOfDeliveries:
           type: number
           description: "[필수] 배달 건수"
@@ -204,9 +209,6 @@ task swaggerConfig {
         imageUrlList:
           type: string
           description: "기존 이미지 URL 리스트 (or null)"
-        jobTitle:
-          type: string
-          description: "[필수] 직업명"
         place:
           type: string
           description: "[필수] 현장명"
@@ -231,6 +233,8 @@ task swaggerConfig {
 			if (line == "  securitySchemes:")
 				writer.print(PostDiaryDTOContent)
 			writer.println(line)
+			if (line == "      operationId: SaveCaddyDiary")
+				writer.print(PostDiaryQueryContent)
 			if (line == "      operationId: SaveCaddyDiary" || line == "      operationId: UpdateCaddyDiary")
 				writer.print(PostDiaryContent)
 		}

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -8,18 +8,22 @@ import blueclub.server.diary.service.DiaryService;
 import blueclub.server.global.response.BaseException;
 import blueclub.server.global.response.BaseResponse;
 import blueclub.server.global.response.BaseResponseStatus;
+import blueclub.server.user.domain.Job;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.YearMonth;
 import java.util.List;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/diary")
@@ -30,13 +34,14 @@ public class DiaryController {
     @PostMapping("")
     public ResponseEntity<BaseResponse> saveDiary(
             @AuthenticationPrincipal UserDetails userDetails,
+            @NotBlank(message = "직업명은 필수입니다") @RequestParam("job") String jobTitle,
             @Valid @RequestPart("dto") UpdateDiaryRequest updateDiaryRequest,
             @RequestPart(value = "image", required = false) List<MultipartFile> multipartFileList) {
-        if (updateDiaryRequest instanceof UpdateCaddyDiaryRequest) {
+        if (Job.CADDY.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateCaddyDiaryRequest) {
             diaryService.saveCaddyDiary(userDetails, (UpdateCaddyDiaryRequest) updateDiaryRequest, multipartFileList);
-        } else if (updateDiaryRequest instanceof UpdateRiderDiaryRequest) {
+        } else if (Job.RIDER.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateRiderDiaryRequest) {
             diaryService.saveRiderDiary(userDetails, (UpdateRiderDiaryRequest) updateDiaryRequest, multipartFileList);
-        } else if (updateDiaryRequest instanceof UpdateDayworkerDiaryRequest) {
+        } else if (Job.DAYWORKER.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateDayworkerDiaryRequest) {
             diaryService.saveDayworkerDiary(userDetails, (UpdateDayworkerDiaryRequest) updateDiaryRequest, multipartFileList);
         } else throw new BaseException(BaseResponseStatus.INVALID_INPUT_DTO);
 
@@ -46,14 +51,15 @@ public class DiaryController {
     @PatchMapping("/{diaryId}")
     public ResponseEntity<BaseResponse> updateDiary(
             @AuthenticationPrincipal UserDetails userDetails,
+            @NotBlank(message = "직업명은 필수입니다") @RequestParam("job") String jobTitle,
             @PathVariable("diaryId") Long diaryId,
             @Valid @RequestPart("dto") UpdateDiaryRequest updateDiaryRequest,
             @RequestPart(value = "image", required = false) List<MultipartFile> multipartFileList) {
-        if (updateDiaryRequest instanceof UpdateCaddyDiaryRequest) {
+        if (Job.CADDY.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateCaddyDiaryRequest) {
             diaryService.updateCaddyDiary(userDetails, diaryId, (UpdateCaddyDiaryRequest) updateDiaryRequest, multipartFileList);
-        } else if (updateDiaryRequest instanceof UpdateRiderDiaryRequest) {
+        } else if (Job.RIDER.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateRiderDiaryRequest) {
             diaryService.updateRiderDiary(userDetails, diaryId, (UpdateRiderDiaryRequest) updateDiaryRequest, multipartFileList);
-        } else if (updateDiaryRequest instanceof UpdateDayworkerDiaryRequest) {
+        } else if (Job.DAYWORKER.getTitle().equals(jobTitle) && updateDiaryRequest instanceof UpdateDayworkerDiaryRequest) {
             diaryService.updateDayworkerDiary(userDetails, diaryId, (UpdateDayworkerDiaryRequest) updateDiaryRequest, multipartFileList);
         } else throw new BaseException(BaseResponseStatus.INVALID_INPUT_DTO);
 
@@ -63,8 +69,9 @@ public class DiaryController {
     @GetMapping("/{diaryId}")
     public ResponseEntity<BaseResponse> getDiaryDetails(
             @AuthenticationPrincipal UserDetails userDetails,
+            @NotBlank(message = "직업명은 필수입니다") @RequestParam("job") String jobTitle,
             @PathVariable("diaryId") Long diaryId) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetails(userDetails, diaryId));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetails(userDetails, jobTitle, diaryId));
     }
 
     @DeleteMapping("/{diaryId}")

--- a/src/main/java/blueclub/server/diary/dto/request/UpdateDiaryRequest.java
+++ b/src/main/java/blueclub/server/diary/dto/request/UpdateDiaryRequest.java
@@ -14,15 +14,12 @@ import java.time.LocalDate;
 import java.util.List;
 
 @JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.EXISTING_PROPERTY,
-        property = "jobTitle",
-        visible = true
+        use = JsonTypeInfo.Id.DEDUCTION
 )
 @JsonSubTypes({
-        @JsonSubTypes.Type(name = "골프 캐디", value = UpdateCaddyDiaryRequest.class),
-        @JsonSubTypes.Type(name = "배달 라이더", value = UpdateRiderDiaryRequest.class),
-        @JsonSubTypes.Type(name = "일용직 노동자", value = UpdateDayworkerDiaryRequest.class)
+        @JsonSubTypes.Type(UpdateCaddyDiaryRequest.class),
+        @JsonSubTypes.Type(UpdateRiderDiaryRequest.class),
+        @JsonSubTypes.Type(UpdateDayworkerDiaryRequest.class)
 })
 @SuperBuilder
 @Getter
@@ -47,7 +44,4 @@ public abstract class UpdateDiaryRequest {
     private LocalDate date;
 
     private List<String> imageUrlList;
-
-    @NotBlank(message = "직업명은 필수입니다")
-    private String jobTitle;
 }

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -172,13 +172,13 @@ public class DiaryService {
     }
 
     @Transactional(readOnly = true)
-    public Object getDiaryDetails(UserDetails userDetails, Long diaryId) {
+    public Object getDiaryDetails(UserDetails userDetails, String jobTitle, Long diaryId) {
         User user = userFindService.findByUserDetails(userDetails);
         List<Diary> diary = diaryRepository.getDiaryById(diaryId);
         if (diary.isEmpty()) {
             throw new BaseException(BaseResponseStatus.DIARY_NOT_FOUND_ERROR);
         }
-        if (user.getJob().equals(Job.CADDY)) {
+        if (Job.CADDY.getTitle().equals(jobTitle)) {
             return GetCaddyDiaryDetailsResponse.builder()
                     .worktype(diary.get(0).getWorktype().getKey())
                     .memo(diary.get(0).getMemo())
@@ -191,7 +191,7 @@ public class DiaryService {
                     .overFee(diary.get(0).getCaddy().getOverFee())
                     .topdressing(diary.get(0).getCaddy().getTopdressing())
                     .build();
-        } else if (user.getJob().equals(Job.RIDER)) {
+        } else if (Job.RIDER.getTitle().equals(jobTitle)) {
             return GetRiderDiaryDetailsResponse.builder()
                     .worktype(diary.get(0).getWorktype().getKey())
                     .memo(diary.get(0).getMemo())
@@ -204,7 +204,7 @@ public class DiaryService {
                     .incomeOfPromotions(diary.get(0).getRider().getIncomeOfPromotions())
                     .numberOfPromotions(diary.get(0).getRider().getNumberOfPromotions())
                     .build();
-        } else if (user.getJob().equals(Job.DAYWORKER)) {
+        } else if (Job.DAYWORKER.getTitle().equals(jobTitle)) {
             return GetDayworkerDiaryDetailsResponse.builder()
                     .worktype(diary.get(0).getWorktype().getKey())
                     .memo(diary.get(0).getMemo())

--- a/src/main/java/blueclub/server/user/controller/UserController.java
+++ b/src/main/java/blueclub/server/user/controller/UserController.java
@@ -2,7 +2,8 @@ package blueclub.server.user.controller;
 
 import blueclub.server.global.response.BaseResponse;
 import blueclub.server.global.response.BaseResponseStatus;
-import blueclub.server.user.dto.request.AddDetailsRequest;
+import blueclub.server.user.dto.request.AddUserDetailsRequest;
+import blueclub.server.user.dto.request.UpdateUserDetailsRequest;
 import blueclub.server.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +23,8 @@ public class UserController {
     @PostMapping("/details")
     public ResponseEntity<BaseResponse> addUserDetails(
             @AuthenticationPrincipal UserDetails userDetails,
-            @Valid @RequestBody AddDetailsRequest addDetailsRequest) {
-        userService.addUserDetails(userDetails, addDetailsRequest);
+            @Valid @RequestBody AddUserDetailsRequest addUserDetailsRequest) {
+        userService.addUserDetails(userDetails, addUserDetailsRequest);
         return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
@@ -31,5 +33,14 @@ public class UserController {
             @AuthenticationPrincipal UserDetails userDetails) {
         userService.withdrawUser(userDetails);
         return BaseResponse.toResponseEntity(BaseResponseStatus.DELETED);
+    }
+
+    @PatchMapping("/details")
+    public ResponseEntity<BaseResponse> updateUserDetails(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestPart("dto") UpdateUserDetailsRequest updateUserDetailsRequest,
+            @RequestPart(value = "image", required = false) MultipartFile multipartFile
+            ) {
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 }

--- a/src/main/java/blueclub/server/user/dto/request/AddUserDetailsRequest.java
+++ b/src/main/java/blueclub/server/user/dto/request/AddUserDetailsRequest.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import org.hibernate.validator.constraints.Length;
 
 @Builder
-public record AddDetailsRequest (
+public record AddUserDetailsRequest(
         @NotBlank(message = "닉네임을 입력해주세요")
         @Length(max = 10, message = "닉네임은 10글자 이하로 작성해주세요")
         String nickname,

--- a/src/main/java/blueclub/server/user/dto/request/UpdateUserDetailsRequest.java
+++ b/src/main/java/blueclub/server/user/dto/request/UpdateUserDetailsRequest.java
@@ -1,0 +1,20 @@
+package blueclub.server.user.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
+
+@Builder
+public record UpdateUserDetailsRequest (
+        @NotBlank(message = "닉네임을 입력해주세요")
+        @Length(max = 10, message = "닉네임은 10글자 이하로 작성해주세요")
+        String nickname,
+        @NotBlank(message = "직업을 선택해주세요")
+        String jobTitle,
+        @Min(value = 100000, message = "월 수입 목표는 10만원 이상으로 입력해주세요")
+        @Max(value = 99990000, message = "월 수입 목표는 9999만원 이하로 입력해주세요")
+        Long monthlyTargetIncome
+) {
+}

--- a/src/main/java/blueclub/server/user/service/UserService.java
+++ b/src/main/java/blueclub/server/user/service/UserService.java
@@ -3,7 +3,8 @@ package blueclub.server.user.service;
 import blueclub.server.auth.service.JwtService;
 import blueclub.server.user.domain.Job;
 import blueclub.server.user.domain.User;
-import blueclub.server.user.dto.request.AddDetailsRequest;
+import blueclub.server.user.dto.request.AddUserDetailsRequest;
+import blueclub.server.user.dto.request.UpdateUserDetailsRequest;
 import blueclub.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,14 +20,18 @@ public class UserService {
     private final JwtService jwtService;
     private final UserRepository userRepository;
 
-    public void addUserDetails(UserDetails userDetails, AddDetailsRequest addDetailsRequest) {
+    public void addUserDetails(UserDetails userDetails, AddUserDetailsRequest addUserDetailsRequest) {
         User user = userFindService.findByUserDetails(userDetails);
         user.addDetails(
-                addDetailsRequest.nickname(),
-                Job.findByTitle(addDetailsRequest.jobTitle()),
-                addDetailsRequest.monthlyTargetIncome(),
-                addDetailsRequest.tosAgree()
+                addUserDetailsRequest.nickname(),
+                Job.findByTitle(addUserDetailsRequest.jobTitle()),
+                addUserDetailsRequest.monthlyTargetIncome(),
+                addUserDetailsRequest.tosAgree()
         );
+    }
+
+    public void updateUserDetails(UserDetails userDetails, UpdateUserDetailsRequest updateUserDetailsRequest) {
+
     }
 
     public void withdrawUser(UserDetails userDetails) {

--- a/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
@@ -29,8 +29,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -44,6 +43,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("Diary [Controller Layer] -> DiaryController 테스트")
 public class DiaryControllerTest extends ControllerTest {
+
+    private static final String JOB = "job";
+    private static final String CADDY = "골프 캐디";
+    private static final String RIDER = "배달 라이더";
+    private static final String DAYWORKER = "일용직 노동자";
 
     @Nested
     @DisplayName("근무 일지 작성 API [POST /diary]")
@@ -73,7 +77,8 @@ public class DiaryControllerTest extends ControllerTest {
                     .file(file)
                     .file(mockRequest)
                     .accept(APPLICATION_JSON)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
+                    .queryParam(JOB, CADDY);
 
             // then
             mockMvc.perform(requestBuilder)
@@ -103,7 +108,6 @@ public class DiaryControllerTest extends ControllerTest {
                                     fieldWithPath("saving").type(NUMBER).description("저축액"),
                                     fieldWithPath("date").type(STRING).description("[필수] 근무 일자 // 형식 : yyyy-mm-dd"),
                                     fieldWithPath("imageUrlList").type(ARRAY).description("사진 URL 리스트"),
-                                    fieldWithPath("jobTitle").type(STRING).description("[필수] 직업명"),
                                     fieldWithPath("rounding").type(NUMBER).description("[필수] 라운딩 수"),
                                     fieldWithPath("caddyFee").type(NUMBER).description("[필수] 캐디피 수입"),
                                     fieldWithPath("overFee").type(NUMBER).description("오버피 수입"),
@@ -146,7 +150,8 @@ public class DiaryControllerTest extends ControllerTest {
                     .file(file)
                     .file(mockRequest)
                     .accept(APPLICATION_JSON)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
+                    .queryParam(JOB, CADDY);
 
             requestBuilder.with(new RequestPostProcessor() {
                 @Override
@@ -167,6 +172,9 @@ public class DiaryControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("Diary API")
                                             .summary("근무 일지 수정 API")
+                                            .queryParameters(
+                                                    parameterWithName("job").description("[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                            )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
                                             )
@@ -192,12 +200,13 @@ public class DiaryControllerTest extends ControllerTest {
             // given
             doReturn(getCaddyDiaryDetailsResponse())
                     .when(diaryService)
-                    .getDiaryDetails(any(), anyLong());
+                    .getDiaryDetails(any(), anyString(), anyLong());
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, 1L)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
+                    .queryParam(JOB, CADDY);
 
             // then
             mockMvc.perform(requestBuilder)
@@ -210,6 +219,9 @@ public class DiaryControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
+                                            .queryParameters(
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                            )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
                                             )
@@ -239,12 +251,13 @@ public class DiaryControllerTest extends ControllerTest {
             // given
             doReturn(getRiderDiaryDetailsResponse())
                     .when(diaryService)
-                    .getDiaryDetails(any(), anyLong());
+                    .getDiaryDetails(any(), anyString(), anyLong());
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, 1L)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
+                    .queryParam(JOB, RIDER);
 
             // then
             mockMvc.perform(requestBuilder)
@@ -257,6 +270,9 @@ public class DiaryControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
+                                            .queryParameters(
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                            )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
                                             )
@@ -286,12 +302,13 @@ public class DiaryControllerTest extends ControllerTest {
             // given
             doReturn(getDayworkerDiaryDetailsResponse())
                     .when(diaryService)
-                    .getDiaryDetails(any(), anyLong());
+                    .getDiaryDetails(any(), anyString(), anyLong());
 
             // when
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, 1L)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
+                    .queryParam(JOB, DAYWORKER);
 
             // then
             mockMvc.perform(requestBuilder)
@@ -304,6 +321,9 @@ public class DiaryControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
+                                            .queryParameters(
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                            )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
                                             )
@@ -470,7 +490,6 @@ public class DiaryControllerTest extends ControllerTest {
                 .saving(CADDY_DIARY.getSaving())
                 .date(CADDY_DIARY.getDate())
                 .imageUrlList(CADDY_DIARY.getImageUrlList())
-                .jobTitle(CADDY_DIARY.getJobTitle())
                 .rounding(CADDY_DIARY.getRounding())
                 .caddyFee(CADDY_DIARY.getCaddyFee())
                 .overFee(CADDY_DIARY.getOverFee())

--- a/src/test/java/blueclub/server/user/controller/UserControllerTest.java
+++ b/src/test/java/blueclub/server/user/controller/UserControllerTest.java
@@ -1,7 +1,7 @@
 package blueclub.server.user.controller;
 
 import blueclub.server.global.ControllerTest;
-import blueclub.server.user.dto.request.AddDetailsRequest;
+import blueclub.server.user.dto.request.AddUserDetailsRequest;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import org.junit.jupiter.api.DisplayName;
@@ -39,15 +39,15 @@ public class UserControllerTest extends ControllerTest {
             // given
             doNothing()
                     .when(userService)
-                    .addUserDetails(any(UserDetails.class), any(AddDetailsRequest.class));
+                    .addUserDetails(any(UserDetails.class), any(AddUserDetailsRequest.class));
 
             // when
-            final AddDetailsRequest addDetailsRequest = addDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = addDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -71,7 +71,7 @@ public class UserControllerTest extends ControllerTest {
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result").type(NULL).description("null 반환")
                                             )
-                                            .requestSchema(Schema.schema("AddDetailsRequest"))
+                                            .requestSchema(Schema.schema("AddUserDetailsRequest"))
                                             .responseSchema(Schema.schema("BaseResponse"))
                                             .build()
                             )
@@ -85,12 +85,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "닉네임을 입력해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = blankNicknameAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = blankNicknameAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -132,12 +132,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "닉네임은 10글자 이하로 작성해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = OverLengthNicknameAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = OverLengthNicknameAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -179,12 +179,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "직업을 선택해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = BlankJobTitleAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = BlankJobTitleAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -226,12 +226,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "월 수입 목표는 10만원 이상으로 입력해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = UnderMonthlyTargetIncomeAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = UnderMonthlyTargetIncomeAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -273,12 +273,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "월 수입 목표는 9999만원 이하로 입력해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = OverMonthlyTargetIncomeAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = OverMonthlyTargetIncomeAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -320,12 +320,12 @@ public class UserControllerTest extends ControllerTest {
             String validExceptionMessage = "선택약관 동의여부를 입력해주세요";
 
             // when
-            final AddDetailsRequest addDetailsRequest = NullTosAgreeAddDetailsRequest();
+            final AddUserDetailsRequest addUserDetailsRequest = NullTosAgreeAddDetailsRequest();
             MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL)
                     .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
                     .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(addDetailsRequest));
+                    .content(objectMapper.writeValueAsString(addUserDetailsRequest));
 
             // then
             mockMvc.perform(requestBuilder)
@@ -396,8 +396,8 @@ public class UserControllerTest extends ControllerTest {
         }
     }
 
-    private AddDetailsRequest addDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest addDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname(WIZ.getNickname())
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(WIZ.getMonthlyTargetIncome())
@@ -405,8 +405,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest blankNicknameAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest blankNicknameAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname("")
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(WIZ.getMonthlyTargetIncome())
@@ -414,8 +414,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest OverLengthNicknameAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest OverLengthNicknameAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname("ThisIsOverLengthNickname")
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(WIZ.getMonthlyTargetIncome())
@@ -423,8 +423,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest BlankJobTitleAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest BlankJobTitleAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname(WIZ.getNickname())
                 .jobTitle("")
                 .monthlyTargetIncome(WIZ.getMonthlyTargetIncome())
@@ -432,8 +432,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest UnderMonthlyTargetIncomeAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest UnderMonthlyTargetIncomeAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname(WIZ.getNickname())
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(99L)
@@ -441,8 +441,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest OverMonthlyTargetIncomeAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest OverMonthlyTargetIncomeAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname(WIZ.getNickname())
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(9999999999L)
@@ -450,8 +450,8 @@ public class UserControllerTest extends ControllerTest {
                 .build();
     }
 
-    private AddDetailsRequest NullTosAgreeAddDetailsRequest() {
-        return AddDetailsRequest.builder()
+    private AddUserDetailsRequest NullTosAgreeAddDetailsRequest() {
+        return AddUserDetailsRequest.builder()
                 .nickname(WIZ.getNickname())
                 .jobTitle(WIZ.getJob().getTitle())
                 .monthlyTargetIncome(WIZ.getMonthlyTargetIncome())


### PR DESCRIPTION
## Summary 📌
- 프론트와의 소통 후 근무수첩 Request 변경 및 Swagger 수정
## Describe your changes 📝
- job 을 RequestBody >> QueryString 로 변경
- Requestpart로 입력받는 경우 job 별로 Swagger API 분리가 안 되어 현행 유지
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #61 