### PR TITLE
[Fix] #79 jwt 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '0.6.1-SNAPSHOT'
+version = '0.6.2-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "0.6.1"
+	version = "0.6.2"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }
@@ -55,12 +55,17 @@ task swaggerConfig {
 		def newSwaggerUIFile = new File('build/api-spec/new.yaml')
 
 		def securitySchemesContent =  "  securitySchemes:\n" +  \
-                                      "    bearerAuth:\n" +  \
-                                      "      type: http\n" +  \
-                                      "      scheme: bearer\n" +  \
-                                      "      bearerFormat: JWT\n" + \
+                                      "    Authorization:\n" +  \
+                                      "      type: apiKey\n" +  \
+                                      "      name: Authorization\n" +  \
+                                      "      in: header\n" + \
+									  "    Authorization-refresh:\n" +  \
+                                      "      type: apiKey\n" +  \
+                                      "      name: Authorization-refresh\n" +  \
+                                      "      in: header\n" + \
                                       "security:\n" +
-									  "  - bearerAuth: []"
+									  "  - Authorization: []\n" + \
+ 									  "    Authorization-refresh: []\n"
 
 		swaggerUIFile.append(securitySchemesContent)
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '0.6.2-SNAPSHOT'
+version = '0.6.3-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "0.6.2"
+	version = "0.6.3"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }

--- a/src/main/java/blueclub/server/auth/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/blueclub/server/auth/filter/JwtAuthenticationProcessingFilter.java
@@ -3,8 +3,12 @@ package blueclub.server.auth.filter;
 import blueclub.server.auth.domain.RefreshToken;
 import blueclub.server.auth.repository.RefreshTokenRepository;
 import blueclub.server.auth.service.JwtService;
+import blueclub.server.global.response.BaseException;
+import blueclub.server.global.response.BaseResponse;
+import blueclub.server.global.response.BaseResponseStatus;
 import blueclub.server.user.domain.User;
 import blueclub.server.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +24,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Jwt 인증 필터
@@ -37,7 +44,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
-    private static final String NO_CHECK_URL = "/auth"; // "/auth"으로 들어오는 요청은 Filter 작동 X
+    private static final List<String> NO_CHECK_URL_LIST = List.of(
+            "/auth", "/health", "/css", "/images", "/js", "/favicon.ico", "/swagger", "/docs", "/swagger-ui", "/v3/api-docs", "/error"); // Filter 작동 X
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
@@ -47,33 +55,46 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getRequestURI().equals(NO_CHECK_URL)) {
-            filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
-            return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
+        for (String NO_CHECK_URL: NO_CHECK_URL_LIST) {
+            if (request.getRequestURI().contains(NO_CHECK_URL)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
         }
 
-        // 사용자 요청 헤더에서 RefreshToken 추출
-        // -> RefreshToken이 없거나 유효하지 않다면(DB에 저장된 RefreshToken과 다르다면) null을 반환
-        // 사용자의 요청 헤더에 RefreshToken이 있는 경우는, AccessToken이 만료되어 요청한 경우밖에 없다.
-        // 따라서, 위의 경우를 제외하면 추출한 refreshToken은 모두 null
+        // RefreshToken 유효성 검사
         String refreshToken = jwtService.extractRefreshToken(request)
                 .filter(jwtService::isTokenValid)
+                .filter(jwtService::isRefreshTokenExist)
                 .orElse(null);
 
-        // 리프레시 토큰이 요청 헤더에 존재했다면, 사용자가 AccessToken이 만료되어서
-        // RefreshToken까지 보낸 것이므로 리프레시 토큰이 DB의 리프레시 토큰과 일치하는지 판단 후,
-        // 일치한다면 AccessToken을 재발급해준다.
-        if (refreshToken != null) {
-            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-            return; // RefreshToken을 보낸 경우에는 AccessToken을 재발급 하고 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
+        // RefreshToken 없을 시 or 유효하지 않을 시 401 error
+        if (refreshToken == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("utf-8");
+
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            response.getWriter().write(
+                    objectMapper.writeValueAsString(
+                            BaseResponse.builder()
+                                    .code(BaseResponseStatus.INVALID_JWT.getCode())
+                                    .message(BaseResponseStatus.INVALID_JWT.getMessage())
+                                    .result(null)
+                                    .build()
+                    )
+            );
+            return;
         }
 
-        // RefreshToken이 없거나 유효하지 않다면, AccessToken을 검사하고 인증을 처리하는 로직 수행
-        // AccessToken이 없거나 유효하지 않다면, 인증 객체가 담기지 않은 상태로 다음 필터로 넘어가기 때문에 403 에러 발생
-        // AccessToken이 유효하다면, 인증 객체가 담긴 상태로 다음 필터로 넘어가기 때문에 인증 성공
-        if (refreshToken == null) {
-            checkAccessTokenAndAuthentication(request, response, filterChain);
+        // AccessToken 인증 시 다음 필터 진행
+        if (checkAccessTokenAndAuthentication(request, response, filterChain)) {
+            filterChain.doFilter(request, response);
+            return;
         }
+        // AccessToken 인증 실패 시 재발급
+        checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
     }
 
     /**
@@ -86,7 +107,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
         refreshTokenRepository.findByToken(refreshToken)
                 .ifPresent(token -> {
-                    User user = userRepository.findById(token.getId()).orElseThrow();
+                    User user = userRepository.findById(token.getId())
+                            .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR));
                     String reIssuedRefreshToken = reIssueRefreshToken(token);
                     jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getEmail()),
                             reIssuedRefreshToken);
@@ -113,15 +135,20 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
      * 인증 허가 처리된 객체를 SecurityContextHolder에 담기
      * 그 후 다음 인증 필터로 진행
      */
-    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+    public Boolean checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
                                                   FilterChain filterChain) throws ServletException, IOException {
+        AtomicBoolean isAuthSuccess = new AtomicBoolean(false);
         jwtService.extractAccessToken(request)
                 .filter(jwtService::isTokenValid)
                 .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
-                        .ifPresent(email -> userRepository.findByEmail(email)
-                                .ifPresent(this::saveAuthentication)));
-
-        filterChain.doFilter(request, response);
+                        .ifPresent(email -> {
+                            Optional<User> user = userRepository.findByEmail(email);
+                            if (user.isPresent()) {
+                                saveAuthentication(user.get());
+                                isAuthSuccess.set(true);
+                            }
+                        }));
+        return isAuthSuccess.get();
     }
 
     /**

--- a/src/main/java/blueclub/server/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/blueclub/server/auth/handler/LoginSuccessHandler.java
@@ -12,6 +12,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 
+import java.io.IOException;
+
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
@@ -24,7 +26,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-                                        Authentication authentication) {
+                                        Authentication authentication) throws IOException {
         String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
         String accessToken = jwtService.createAccessToken(email); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
         String refreshToken = jwtService.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급

--- a/src/main/java/blueclub/server/auth/service/JwtService.java
+++ b/src/main/java/blueclub/server/auth/service/JwtService.java
@@ -3,10 +3,12 @@ package blueclub.server.auth.service;
 import blueclub.server.auth.domain.RefreshToken;
 import blueclub.server.auth.repository.RefreshTokenRepository;
 import blueclub.server.global.response.BaseException;
+import blueclub.server.global.response.BaseResponse;
 import blueclub.server.global.response.BaseResponseStatus;
 import blueclub.server.user.repository.UserRepository;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
@@ -15,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.Optional;
 
@@ -90,11 +93,26 @@ public class JwtService {
     /**
      * AccessToken + RefreshToken 헤더에 실어서 보내기
      */
-    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FOUND);
 
         setAccessTokenHeader(response, accessToken);
         setRefreshTokenHeader(response, refreshToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                        BaseResponse.builder()
+                                .code(BaseResponseStatus.RETRY_REQUEST.getCode())
+                                .message(BaseResponseStatus.RETRY_REQUEST.getMessage())
+                                .result(null)
+                                .build()
+                )
+        );
     }
 
     /**

--- a/src/main/java/blueclub/server/auth/service/JwtService.java
+++ b/src/main/java/blueclub/server/auth/service/JwtService.java
@@ -185,5 +185,10 @@ public class JwtService {
             return false;
         }
     }
+
+    public boolean isRefreshTokenExist(String refreshToken) {
+        return refreshTokenRepository.findByToken(refreshToken)
+                .isPresent();
+    }
 }
 

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -29,6 +29,7 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
      */
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "REQUEST_ERROR_001", "잘못된 요청입니다."),
     INVALID_INPUT_DTO(HttpStatus.BAD_REQUEST, "REQUEST_ERROR_002", "잘못된 DTO 형식입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "REQUEST_ERROR_003", "로그인 후 이용해주세요."),
 
     // Auth
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_001", "이메일 형식이 올바르지 않습니다."),

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -22,7 +22,8 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     /**
      * 300 : 리다이렉션
      */
-    SEE_OTHER(HttpStatus.SEE_OTHER, "REDIRECT", "다른 주소로 요청해주세요."),
+    SEE_OTHER(HttpStatus.SEE_OTHER, "REDIRECT_001", "다른 주소로 요청해주세요."),
+    RETRY_REQUEST(HttpStatus.FOUND, "REDIRECT_002", "재발급된 AccessToken / RefreshToken 으로 재시도 해주세요."),
 
     /**
      * 400 : 요청 실패


### PR DESCRIPTION
## Summary 📌
- 입력 헤더에 refreshtoken 주입 시 자동으로 accesstoken 재발급
## Describe your changes 📝
- Swagger header 설정 변경
- accesstoken 인증 성공 시
  - 이후 정상적인 로직 진행
- accesstoken 인증 실패, refreshtoken 인증 성공 시
  - response status : 302
  - response 헤더를 통해 갱신된 accesstoken, refreshtoken 전송
- accesstoken 인증 실패 뒤 refreshtoken 인증 실패 시
  - response status : 401 error
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #79 