### PR TITLE
[Feat] #106 fcm token 저장 API 설계 및 기타 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '0.10.0-SNAPSHOT'
+version = '0.11.0-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "0.10.0"
+	version = "0.11.0"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }

--- a/src/main/java/blueclub/server/auth/controller/AuthController.java
+++ b/src/main/java/blueclub/server/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
@@ -51,6 +52,17 @@ public class AuthController {
     public ResponseEntity<BaseResponse> logout(@AuthenticationPrincipal UserDetails userDetails
     ) {
         authService.logout(userDetails);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
+    }
+
+    @PostMapping("/fcm")
+    public ResponseEntity<BaseResponse> addFcmToken(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("token")
+            @NotBlank(message = "fcm token을 입력해주세요")
+            String fcmToken
+    ) {
+        authService.addFcmToken(userDetails, fcmToken);
         return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 }

--- a/src/main/java/blueclub/server/auth/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/blueclub/server/auth/filter/JwtAuthenticationProcessingFilter.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final List<String> NO_CHECK_URL_LIST = List.of(
-            "/auth", "/health", "/css", "/image", "/js", "/favicon.ico", "/swagger", "/docs", "/swagger-ui", "/v3/api-docs", "/error"); // Filter 작동 X
+            "/health", "/css", "/image", "/js", "/favicon.ico", "/swagger", "/docs", "/swagger-ui", "/v3/api-docs", "/error"); // Filter 작동 X
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
@@ -55,7 +55,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         for (String NO_CHECK_URL: NO_CHECK_URL_LIST) {
-            if (request.getRequestURI().contains(NO_CHECK_URL) && !request.getRequestURI().equals("/auth/duplicated")) {
+            if (request.getRequestURI().contains(NO_CHECK_URL) || request.getRequestURI().equals("/auth")) {
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/blueclub/server/auth/service/AuthService.java
+++ b/src/main/java/blueclub/server/auth/service/AuthService.java
@@ -90,6 +90,11 @@ public class AuthService {
         fcmTokenService.deleteFcmToken(user.getId());
     }
 
+    public void addFcmToken(UserDetails userDetails, String fcmToken) {
+        User user = userFindService.findByUserDetails(userDetails);
+        fcmTokenService.saveFcmToken(user.getId(), fcmToken);
+    }
+
     // 분기 처리, 유저 정보 반환
     private User isRegister(SocialLoginRequest socialLoginRequest) {
         SocialType socialType = SocialType.valueOf(socialLoginRequest.socialType().toUpperCase());

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -102,7 +102,7 @@ public class DiaryController {
             @PathVariable("diaryId") Long diaryId
     ) {
         diaryService.deleteDiary(userDetails, diaryId);
-        return BaseResponse.toResponseEntity(BaseResponseStatus.DELETED);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
     @GetMapping("/list/{yearMonth}")

--- a/src/main/java/blueclub/server/diary/dto/response/GetCaddyDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetCaddyDiaryDetailsResponse.java
@@ -1,21 +1,26 @@
 package blueclub.server.diary.dto.response;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
-@Builder
-public record GetCaddyDiaryDetailsResponse (
-        String worktype,
-        String memo,
-        List<String> imageUrlList,
-        Long income,
-        Long expenditure,
-        Long saving,
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCaddyDiaryDetailsResponse extends GetDiaryIdResponse {
+    private String worktype;
+    private String memo;
+    private List<String> imageUrlList;
+    private Long income;
+    private Long expenditure;
+    private Long saving;
 
-        Long rounding,
-        Long caddyFee,
-        Long overFee,
-        Boolean topdressing
-) {
+    private Long rounding;
+    private Long caddyFee;
+    private Long overFee;
+    private Boolean topdressing;
 }

--- a/src/main/java/blueclub/server/diary/dto/response/GetDayOffDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetDayOffDiaryDetailsResponse.java
@@ -1,9 +1,14 @@
 package blueclub.server.diary.dto.response;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-@Builder
-public record GetDayOffDiaryDetailsResponse(
-        String worktype
-) {
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetDayOffDiaryDetailsResponse extends GetDiaryIdResponse {
+    private String worktype;
 }

--- a/src/main/java/blueclub/server/diary/dto/response/GetDayworkerDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetDayworkerDiaryDetailsResponse.java
@@ -1,21 +1,26 @@
 package blueclub.server.diary.dto.response;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
-@Builder
-public record GetDayworkerDiaryDetailsResponse(
-        String worktype,
-        String memo,
-        List<String> imageUrlList,
-        Long income,
-        Long expenditure,
-        Long saving,
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetDayworkerDiaryDetailsResponse extends GetDiaryIdResponse {
+    private String worktype;
+    private String memo;
+    private List<String> imageUrlList;
+    private Long income;
+    private Long expenditure;
+    private Long saving;
 
-        String place,
-        Long dailyWage,
-        String typeOfJob,
-        Double numberOfWork
-) {
+    private String place;
+    private Long dailyWage;
+    private String typeOfJob;
+    private Double numberOfWork;
 }

--- a/src/main/java/blueclub/server/diary/dto/response/GetDiaryIdResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetDiaryIdResponse.java
@@ -1,6 +1,16 @@
 package blueclub.server.diary.dto.response;
 
-public record GetDiaryIdResponse(
-        Long id
-) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetDiaryIdResponse {
+    private Long id;
 }

--- a/src/main/java/blueclub/server/diary/dto/response/GetRiderDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetRiderDiaryDetailsResponse.java
@@ -1,21 +1,26 @@
 package blueclub.server.diary.dto.response;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
-@Builder
-public record GetRiderDiaryDetailsResponse(
-        String worktype,
-        String memo,
-        List<String> imageUrlList,
-        Long income,
-        Long expenditure,
-        Long saving,
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetRiderDiaryDetailsResponse extends GetDiaryIdResponse {
+    private String worktype;
+    private String memo;
+    private List<String> imageUrlList;
+    private Long income;
+    private Long expenditure;
+    private Long saving;
 
-        Long numberOfDeliveries,
-        Long incomeOfDeliveries,
-        Long numberOfPromotions,
-        Long incomeOfPromotions
-) {
+    private Long numberOfDeliveries;
+    private Long incomeOfDeliveries;
+    private Long numberOfPromotions;
+    private Long incomeOfPromotions;
 }

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -229,7 +229,7 @@ public class DiaryService {
             throw new BaseException(BaseResponseStatus.DIARY_NOT_FOUND_ERROR);
         }
 
-        return getDiaryDetailsSplitByCase(jobTitle, diary.get(0));
+        return getDiaryDetailsSplitByCase(jobTitle, diary.get(0), true);
     }
 
     @Transactional(readOnly = true)
@@ -242,7 +242,7 @@ public class DiaryService {
         if (diary.isEmpty())
             return null;
 
-        return getDiaryDetailsSplitByCase(jobTitle, diary.get(0));
+        return getDiaryDetailsSplitByCase(jobTitle, diary.get(0), false);
     }
 
     public void deleteDiary(UserDetails userDetails, Long diaryId) {
@@ -424,15 +424,36 @@ public class DiaryService {
         throw new BaseException(BaseResponseStatus.JOB_NOT_FOUND_ERROR);
     }
 
-    private Object getDiaryDetailsSplitByCase(String jobTitle, Diary diary) {
+    private Object getDiaryDetailsSplitByCase(String jobTitle, Diary diary, Boolean hasId) {
         if (diary.getWorktype().equals(Worktype.DAY_OFF)) {
+            if (hasId) {
+                return GetDayOffDiaryDetailsResponse.builder()
+                        .worktype(Worktype.DAY_OFF.getValue())
+                        .build();
+            }
             return GetDayOffDiaryDetailsResponse.builder()
+                    .id(diary.getId())
                     .worktype(Worktype.DAY_OFF.getValue())
                     .build();
         }
 
         if (Job.CADDY.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetCaddyDiaryDetailsResponse.builder()
+                        .worktype(diary.getWorktype().getValue())
+                        .memo(diary.getMemo())
+                        .imageUrlList(diary.getImage())
+                        .income(diary.getIncome())
+                        .expenditure(diary.getExpenditure())
+                        .saving(diary.getSaving())
+                        .rounding(diary.getCaddy().getRounding())
+                        .caddyFee(diary.getCaddy().getCaddyFee())
+                        .overFee(diary.getCaddy().getOverFee())
+                        .topdressing(diary.getCaddy().getTopdressing())
+                        .build();
+            }
             return GetCaddyDiaryDetailsResponse.builder()
+                    .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())
@@ -445,7 +466,22 @@ public class DiaryService {
                     .topdressing(diary.getCaddy().getTopdressing())
                     .build();
         } else if (Job.RIDER.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetRiderDiaryDetailsResponse.builder()
+                        .worktype(diary.getWorktype().getValue())
+                        .memo(diary.getMemo())
+                        .imageUrlList(diary.getImage())
+                        .income(diary.getIncome())
+                        .expenditure(diary.getExpenditure())
+                        .saving(diary.getSaving())
+                        .incomeOfDeliveries(diary.getRider().getIncomeOfDeliveries())
+                        .numberOfDeliveries(diary.getRider().getNumberOfDeliveries())
+                        .incomeOfPromotions(diary.getRider().getIncomeOfPromotions())
+                        .numberOfPromotions(diary.getRider().getNumberOfPromotions())
+                        .build();
+            }
             return GetRiderDiaryDetailsResponse.builder()
+                    .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())
@@ -458,7 +494,22 @@ public class DiaryService {
                     .numberOfPromotions(diary.getRider().getNumberOfPromotions())
                     .build();
         } else if (Job.DAYWORKER.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetDayworkerDiaryDetailsResponse.builder()
+                        .worktype(diary.getWorktype().getValue())
+                        .memo(diary.getMemo())
+                        .imageUrlList(diary.getImage())
+                        .income(diary.getIncome())
+                        .expenditure(diary.getExpenditure())
+                        .saving(diary.getSaving())
+                        .place(diary.getDayworker().getPlace())
+                        .dailyWage(diary.getDayworker().getDailyWage())
+                        .typeOfJob(diary.getDayworker().getTypeOfJob())
+                        .numberOfWork(diary.getDayworker().getNumberOfWork())
+                        .build();
+            }
             return GetDayworkerDiaryDetailsResponse.builder()
+                    .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())

--- a/src/main/java/blueclub/server/notice/controller/NoticeController.java
+++ b/src/main/java/blueclub/server/notice/controller/NoticeController.java
@@ -47,7 +47,7 @@ public class NoticeController {
             @PathVariable("noticeId") Long id
     ) {
         noticeService.deleteNotice(id);
-        return BaseResponse.toResponseEntity(BaseResponseStatus.DELETED);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
     @PreAuthorize("hasRole('USER')")

--- a/src/main/java/blueclub/server/reminder/controller/ReminderController.java
+++ b/src/main/java/blueclub/server/reminder/controller/ReminderController.java
@@ -48,7 +48,7 @@ public class ReminderController {
             @PathVariable("reminderId") Long id
     ) {
         reminderService.deleteReminder(id);
-        return BaseResponse.toResponseEntity(BaseResponseStatus.DELETED);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
     @PreAuthorize("hasRole('USER')")

--- a/src/main/java/blueclub/server/user/controller/UserController.java
+++ b/src/main/java/blueclub/server/user/controller/UserController.java
@@ -30,13 +30,13 @@ public class UserController {
         return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasAnyRole('GUEST', 'USER')")
     @DeleteMapping("/withdrawal")
     public ResponseEntity<BaseResponse> withdrawUser(
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         userService.withdrawUser(userDetails);
-        return BaseResponse.toResponseEntity(BaseResponseStatus.DELETED);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
     }
 
     @PreAuthorize("hasRole('USER')")

--- a/src/test/java/blueclub/server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/blueclub/server/auth/controller/AuthControllerTest.java
@@ -495,7 +495,7 @@ public class AuthControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("로그아웃 API [GET /auth/logout]")
+    @DisplayName("로그아웃 API [POST /auth/logout]")
     class logout {
         private static final String BASE_URL = "/auth/logout";
 
@@ -523,6 +523,52 @@ public class AuthControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("Auth API")
                                             .summary("로그아웃 API")
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
+                                            .build()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @DisplayName("fcm token 저장 API [POST /auth/fcm]")
+    class addFcmToken {
+        private static final String BASE_URL = "/auth/fcm";
+        private static final String FCM_TOKEN = "exampletokenname";
+
+        @Test
+        @DisplayName("fcm token 저장에 성공한다")
+        void addFcmTokenSuccess() throws Exception {
+            // given
+            doNothing()
+                    .when(authService)
+                    .addFcmToken(any(), anyString());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .queryParam("token", FCM_TOKEN)
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isOk())
+                    .andDo(document(
+                            "AddFcmToken",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("Auth API")
+                                            .summary("fcm token 저장 API")
+                                            .queryParameters(
+                                                    parameterWithName("token").description("[필수] fcm token")
+                                            )
                                             .responseFields(
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),

--- a/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
@@ -526,7 +526,7 @@ public class DiaryControllerTest extends ControllerTest {
         @DisplayName("골프 캐디의 날짜로 근무 일지 상세조회에 성공한다")
         void getCaddyDiaryDetailsSuccess() throws Exception {
             // given
-            doReturn(getCaddyDiaryDetailsResponse())
+            doReturn(getCaddyDiaryDetailsByDateResponse())
                     .when(diaryService)
                     .getDiaryDetailsByDate(any(), anyString(), any(LocalDate.class));
 
@@ -555,6 +555,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .responseFields(
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
@@ -566,7 +567,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.overFee").type(NUMBER).description("[DEFAULT 0] 오버피 수입"),
                                                     fieldWithPath("result.topdressing").type(BOOLEAN).description("[DEFAULT FALSE] 배토 여부")
                                             )
-                                            .responseSchema(Schema.schema("GetCaddyDiaryDetailsResponse"))
+                                            .responseSchema(Schema.schema("GetCaddyDiaryDetailsByDateResponse"))
                                             .build()
                             )
                     ));
@@ -576,7 +577,7 @@ public class DiaryControllerTest extends ControllerTest {
         @DisplayName("배달 라이더의 날짜로 근무 일지 상세조회에 성공한다")
         void getRiderDiaryDetailsSuccess() throws Exception {
             // given
-            doReturn(getRiderDiaryDetailsResponse())
+            doReturn(getRiderDiaryDetailsByDateResponse())
                     .when(diaryService)
                     .getDiaryDetailsByDate(any(), anyString(), any(LocalDate.class));
 
@@ -605,6 +606,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .responseFields(
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
@@ -616,7 +618,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.numberOfPromotions").type(NUMBER).description("[DEFAULT 0] 프로모션 건수"),
                                                     fieldWithPath("result.incomeOfPromotions").type(NUMBER).description("[DEFAULT 0] 프로모션 수입")
                                             )
-                                            .responseSchema(Schema.schema("GetRiderDiaryDetailsResponse"))
+                                            .responseSchema(Schema.schema("GetRiderDiaryDetailsByDateResponse"))
                                             .build()
                             )
                     ));
@@ -626,7 +628,7 @@ public class DiaryControllerTest extends ControllerTest {
         @DisplayName("일용직 노동자의 날짜로 근무 일지 상세조회에 성공한다")
         void getDayworkerDiaryDetailsSuccess() throws Exception {
             // given
-            doReturn(getDayworkerDiaryDetailsResponse())
+            doReturn(getDayworkerDiaryDetailsByDateResponse())
                     .when(diaryService)
                     .getDiaryDetailsByDate(any(), anyString(), any(LocalDate.class));
 
@@ -654,6 +656,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .responseFields(
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
@@ -665,7 +668,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.typeOfJob").type(STRING).description("[DEFAULT NULL] 직종"),
                                                     fieldWithPath("result.numberOfWork").type(NUMBER).description("[DEFAULT 0.0] 공수")
                                             )
-                                            .responseSchema(Schema.schema("GetDayworkerDiaryDetailsResponse"))
+                                            .responseSchema(Schema.schema("GetDayworkerDiaryDetailsByDateResponse"))
                                             .build()
                             )
                     ));
@@ -675,7 +678,7 @@ public class DiaryControllerTest extends ControllerTest {
         @DisplayName("날짜로 휴무 근무 일지 상세조회에 성공한다")
         void getDayOffDiaryDetailsSuccess() throws Exception {
             // given
-            doReturn(getDayOffDiaryDetailsResponse())
+            doReturn(getDayOffDiaryDetailsByDateResponse())
                     .when(diaryService)
                     .getDiaryDetailsByDate(any(), anyString(), any(LocalDate.class));
 
@@ -704,9 +707,10 @@ public class DiaryControllerTest extends ControllerTest {
                                             .responseFields(
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태")
                                             )
-                                            .responseSchema(Schema.schema("GetDayOffDiaryDetailsResponse"))
+                                            .responseSchema(Schema.schema("GetDayOffDiaryDetailsByDateResponse"))
                                             .build()
                             )
                     ));
@@ -774,7 +778,7 @@ public class DiaryControllerTest extends ControllerTest {
 
             // then
             mockMvc.perform(requestBuilder)
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isOk())
                     .andDo(document(
                             "DeleteDiary",
                             preprocessRequest(prettyPrint()),
@@ -786,6 +790,12 @@ public class DiaryControllerTest extends ControllerTest {
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
                                             )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
                                             .build()
                             )
                     ));
@@ -1051,6 +1061,61 @@ public class DiaryControllerTest extends ControllerTest {
 
     private GetDayOffDiaryDetailsResponse getDayOffDiaryDetailsResponse() {
         return GetDayOffDiaryDetailsResponse.builder()
+                .worktype(Worktype.DAY_OFF.getValue())
+                .build();
+    }
+
+    private GetCaddyDiaryDetailsResponse getCaddyDiaryDetailsByDateResponse() {
+        return GetCaddyDiaryDetailsResponse.builder()
+                .id(DAYWORKER_DIARY.getId())
+                .worktype(CADDY_DIARY.getWorktype())
+                .memo(CADDY_DIARY.getMemo())
+                .imageUrlList(CADDY_DIARY.getImageUrlList())
+                .income(CADDY_DIARY.getIncome())
+                .expenditure(CADDY_DIARY.getExpenditure())
+                .saving(CADDY_DIARY.getSaving())
+                .rounding(CADDY_DIARY.getRounding())
+                .caddyFee(CADDY_DIARY.getCaddyFee())
+                .overFee(CADDY_DIARY.getOverFee())
+                .topdressing(CADDY_DIARY.getTopdressing())
+                .build();
+    }
+
+    private GetRiderDiaryDetailsResponse getRiderDiaryDetailsByDateResponse() {
+        return GetRiderDiaryDetailsResponse.builder()
+                .id(DAYWORKER_DIARY.getId())
+                .worktype(RIDER_DIARY.getWorktype())
+                .memo(RIDER_DIARY.getMemo())
+                .imageUrlList(RIDER_DIARY.getImageUrlList())
+                .income(RIDER_DIARY.getIncome())
+                .expenditure(RIDER_DIARY.getExpenditure())
+                .saving(RIDER_DIARY.getSaving())
+                .numberOfDeliveries(RIDER_DIARY.getNumberOfDeliveries())
+                .incomeOfDeliveries(RIDER_DIARY.getIncomeOfDeliveries())
+                .numberOfPromotions(RIDER_DIARY.getNumberOfPromotions())
+                .incomeOfPromotions(RIDER_DIARY.getIncomeOfPromotions())
+                .build();
+    }
+
+    private GetDayworkerDiaryDetailsResponse getDayworkerDiaryDetailsByDateResponse() {
+        return GetDayworkerDiaryDetailsResponse.builder()
+                .id(DAYWORKER_DIARY.getId())
+                .worktype(DAYWORKER_DIARY.getWorktype())
+                .memo(DAYWORKER_DIARY.getMemo())
+                .imageUrlList(DAYWORKER_DIARY.getImageUrlList())
+                .income(DAYWORKER_DIARY.getIncome())
+                .expenditure(DAYWORKER_DIARY.getExpenditure())
+                .saving(DAYWORKER_DIARY.getSaving())
+                .place(DAYWORKER_DIARY.getPlace())
+                .dailyWage(DAYWORKER_DIARY.getDailyWage())
+                .typeOfJob(DAYWORKER_DIARY.getTypeOfJob())
+                .numberOfWork(DAYWORKER_DIARY.getNumberOfWork())
+                .build();
+    }
+
+    private GetDayOffDiaryDetailsResponse getDayOffDiaryDetailsByDateResponse() {
+        return GetDayOffDiaryDetailsResponse.builder()
+                .id(DAYWORKER_DIARY.getId())
                 .worktype(Worktype.DAY_OFF.getValue())
                 .build();
     }

--- a/src/test/java/blueclub/server/fixture/diary/DayworkerDiaryFixture.java
+++ b/src/test/java/blueclub/server/fixture/diary/DayworkerDiaryFixture.java
@@ -12,11 +12,12 @@ import static blueclub.server.user.domain.Job.DAYWORKER;
 @Getter
 @RequiredArgsConstructor
 public enum DayworkerDiaryFixture {
-    DAYWORKER_DIARY(Worktype.WORKING.getValue(), "memo3", 300000L, 0L, 0L, LocalDate.now().minusDays(2),
+    DAYWORKER_DIARY(1L, Worktype.WORKING.getValue(), "memo3", 300000L, 0L, 0L, LocalDate.now().minusDays(2),
             List.of("https://blueclubs3.s3.ap-northeast-2.amazonaws.com/diary/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202023-06-13%20%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%A5%E1%86%AB%201.44.20.png"),
             DAYWORKER.getTitle(),
             "00건설", 300000L, "창호", 1.0);
 
+    private final Long id;
     private final String worktype;
     private final String memo;
     private final Long income;

--- a/src/test/java/blueclub/server/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/blueclub/server/notice/controller/NoticeControllerTest.java
@@ -155,7 +155,7 @@ public class NoticeControllerTest extends ControllerTest {
 
             // then
             mockMvc.perform(requestBuilder)
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isOk())
                     .andDo(document(
                             "DeleteNotice",
                             preprocessRequest(prettyPrint()),
@@ -167,6 +167,12 @@ public class NoticeControllerTest extends ControllerTest {
                                             .pathParameters(
                                                     parameterWithName("noticeId").description("공지글 ID")
                                             )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
                                             .build()
                             )
                     ));

--- a/src/test/java/blueclub/server/reminder/controller/ReminderControllerTest.java
+++ b/src/test/java/blueclub/server/reminder/controller/ReminderControllerTest.java
@@ -154,7 +154,7 @@ public class ReminderControllerTest extends ControllerTest {
 
             // then
             mockMvc.perform(requestBuilder)
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isOk())
                     .andDo(document(
                             "DeleteReminder",
                             preprocessRequest(prettyPrint()),
@@ -166,6 +166,12 @@ public class ReminderControllerTest extends ControllerTest {
                                             .pathParameters(
                                                     parameterWithName("reminderId").description("알림 ID")
                                             )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
                                             .build()
                             )
                     ));

--- a/src/test/java/blueclub/server/user/controller/UserControllerTest.java
+++ b/src/test/java/blueclub/server/user/controller/UserControllerTest.java
@@ -385,7 +385,7 @@ public class UserControllerTest extends ControllerTest {
 
             // then
             mockMvc.perform(requestBuilder)
-                    .andExpect(status().isNoContent())
+                    .andExpect(status().isOk())
                     .andDo(document(
                             "UserWithdrawal",
                             preprocessRequest(prettyPrint()),
@@ -394,6 +394,12 @@ public class UserControllerTest extends ControllerTest {
                                     ResourceSnippetParameters.builder()
                                             .tag("User API")
                                             .summary("회원 탈퇴 API")
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
                                             .build()
                             )
                     ));


### PR DESCRIPTION
## Summary 📌
- 로그인 시 이외에, 앱을 켤 때 fcm token 저장 필요
- #103 누락된 response field 추가
- delete API response field 통일 (204 X)
## Describe your changes 📝
- fcm token 저장 API 설계
- 날짜로 근무기록 조회 시 response >> diaryId 추가
- delete API http status 204 >> 200
- 회원탈퇴 권한 수정
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #106 