### PR TITLE
[Feat] #112 날짜 형식 validation 추가 및 근무 기록 로직 통일

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '0.11.1-SNAPSHOT'
+version = '1.0.0-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "0.11.1"
+	version = "1.0.0"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @PreAuthorize("hasRole('USER')")
@@ -93,7 +94,7 @@ public class DiaryController {
             @RequestParam("date")
             String date
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle, LocalDate.parse(date)));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle, LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-M-d"))));
     }
 
     @DeleteMapping("/{diaryId}")
@@ -112,7 +113,7 @@ public class DiaryController {
             @PathVariable("yearMonth")
             String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyList(userDetails, YearMonth.parse(yearMonth)));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyList(userDetails, YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-M"))));
     }
 
     @GetMapping("/record/{yearMonth}")
@@ -122,7 +123,7 @@ public class DiaryController {
             @PathVariable("yearMonth")
             String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyRecord(userDetails, YearMonth.parse(yearMonth)));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyRecord(userDetails, YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-M"))));
     }
 
     @GetMapping("/boast/{diaryId}")

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -108,7 +108,7 @@ public class DiaryController {
     @GetMapping("/list/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyList(
             @AuthenticationPrincipal UserDetails userDetails,
-            @LocalDatePattern(pattern = "yyyy-MM")
+            @LocalDatePattern(pattern = "yyyy-M")
             @PathVariable("yearMonth")
             String yearMonth
     ) {
@@ -118,7 +118,7 @@ public class DiaryController {
     @GetMapping("/record/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyRecord(
             @AuthenticationPrincipal UserDetails userDetails,
-            @LocalDatePattern(pattern = "yyyy-MM")
+            @LocalDatePattern(pattern = "yyyy-M")
             @PathVariable("yearMonth")
             String yearMonth
     ) {

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -6,6 +6,7 @@ import blueclub.server.diary.dto.request.UpdateCaddyDiaryRequest;
 import blueclub.server.diary.dto.request.UpdateDayworkerDiaryRequest;
 import blueclub.server.diary.dto.request.UpdateRiderDiaryRequest;
 import blueclub.server.diary.service.DiaryService;
+import blueclub.server.global.annotation.LocalDatePattern;
 import blueclub.server.global.response.BaseException;
 import blueclub.server.global.response.BaseResponse;
 import blueclub.server.global.response.BaseResponseStatus;
@@ -13,7 +14,6 @@ import blueclub.server.user.domain.Job;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -89,11 +89,11 @@ public class DiaryController {
             @NotBlank(message = "직업명은 필수입니다")
             @RequestParam("job")
             String jobTitle,
-            @DateTimeFormat(pattern = "yyyy-mm-dd")
+            @LocalDatePattern
             @RequestParam("date")
-            LocalDate date
+            String date
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle, date));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle, LocalDate.parse(date)));
     }
 
     @DeleteMapping("/{diaryId}")
@@ -108,17 +108,21 @@ public class DiaryController {
     @GetMapping("/list/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyList(
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable("yearMonth") @DateTimeFormat(pattern = "yyyy-mm") YearMonth yearMonth
+            @LocalDatePattern(pattern = "yyyy-MM")
+            @PathVariable("yearMonth")
+            String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyList(userDetails, yearMonth));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyList(userDetails, YearMonth.parse(yearMonth)));
     }
 
     @GetMapping("/record/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyRecord(
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable("yearMonth") @DateTimeFormat(pattern = "yyyy-mm") YearMonth yearMonth
+            @LocalDatePattern(pattern = "yyyy-MM")
+            @PathVariable("yearMonth")
+            String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyRecord(userDetails, yearMonth));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getMonthlyRecord(userDetails, YearMonth.parse(yearMonth)));
     }
 
     @GetMapping("/boast/{diaryId}")

--- a/src/main/java/blueclub/server/diary/dto/request/UpdateBaseDiaryRequest.java
+++ b/src/main/java/blueclub/server/diary/dto/request/UpdateBaseDiaryRequest.java
@@ -1,5 +1,6 @@
 package blueclub.server.diary.dto.request;
 
+import blueclub.server.global.annotation.LocalDatePattern;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.validation.constraints.NotBlank;
@@ -8,9 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDate;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.DEDUCTION,
@@ -31,7 +29,7 @@ public class UpdateBaseDiaryRequest {
     @NotBlank(message = "근무 형태는 필수입니다")
     private String worktype;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @LocalDatePattern
     @NotNull(message = "근무 날짜는 필수입니다")
-    private LocalDate date;
+    private String date;
 }

--- a/src/main/java/blueclub/server/diary/dto/response/GetCaddyDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetCaddyDiaryDetailsResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class GetCaddyDiaryDetailsResponse extends GetDiaryIdResponse {
     private String worktype;
+    private String date;
     private String memo;
     private List<String> imageUrlList;
     private Long income;

--- a/src/main/java/blueclub/server/diary/dto/response/GetDayworkerDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetDayworkerDiaryDetailsResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class GetDayworkerDiaryDetailsResponse extends GetDiaryIdResponse {
     private String worktype;
+    private String date;
     private String memo;
     private List<String> imageUrlList;
     private Long income;

--- a/src/main/java/blueclub/server/diary/dto/response/GetRiderDiaryDetailsResponse.java
+++ b/src/main/java/blueclub/server/diary/dto/response/GetRiderDiaryDetailsResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class GetRiderDiaryDetailsResponse extends GetDiaryIdResponse {
     private String worktype;
+    private String date;
     private String memo;
     private List<String> imageUrlList;
     private Long income;

--- a/src/main/java/blueclub/server/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/blueclub/server/diary/repository/DiaryQueryRepositoryImpl.java
@@ -26,7 +26,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
                 .from(diary)
                 .where(diary.user.eq(user),
                         diary.workAt.year().eq(yearMonth.getYear()),
-                        diary.workAt.month().eq(yearMonth.getMonthValue()))
+                        diary.workAt.month().eq(yearMonth.getMonthValue()),
+                        diary.job.eq(user.getJob()))
                 .fetch();
         return totalMonthlyIncome.get(0) != null ? totalMonthlyIncome.get(0) : 0;
     }
@@ -87,7 +88,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
                 .from(diary)
                 .where(diary.user.eq(user),
                         diary.workAt.year().eq(workAt.getYear()),
-                        diary.workAt.month().eq(workAt.getMonthValue()))
+                        diary.workAt.month().eq(workAt.getMonthValue()),
+                        diary.job.eq(user.getJob()))
                 .orderBy(diary.workAt.desc())
                 .fetch();
 
@@ -108,7 +110,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
         List<LocalDate> workAtList = queryFactory
                 .selectDistinct(diary.workAt)
                 .from(diary)
-                .where(diary.user.eq(user))
+                .where(diary.user.eq(user),
+                        diary.job.eq(user.getJob()))
                 .orderBy(diary.workAt.desc())
                 .fetch();
 
@@ -145,7 +148,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
         List<LocalDate> workAtList = queryFactory
                 .selectDistinct(diary.workAt)
                 .from(diary)
-                .where(diary.user.eq(user))
+                .where(diary.user.eq(user),
+                        diary.job.eq(user.getJob()))
                 .orderBy(diary.workAt.desc())
                 .fetch();
 

--- a/src/main/java/blueclub/server/diary/repository/DiaryRepository.java
+++ b/src/main/java/blueclub/server/diary/repository/DiaryRepository.java
@@ -1,6 +1,8 @@
 package blueclub.server.diary.repository;
 
 import blueclub.server.diary.domain.Diary;
+import blueclub.server.user.domain.Job;
+import blueclub.server.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -8,4 +10,5 @@ import java.time.LocalDate;
 public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryQueryRepository {
 
     Boolean existsByWorkAt(LocalDate workAt);
+    Boolean existsByUserAndWorkAtAndJob(User user, LocalDate workAt, Job job);
 }

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -49,7 +49,7 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveDayOffDiary(UserDetails userDetails, UpdateBaseDiaryRequest updateBaseDiaryRequest) {
         User user = userFindService.findByUserDetails(userDetails);
-        Diary diary = diaryRepository.save(saveBaseDiary(user, Worktype.DAY_OFF, updateBaseDiaryRequest.getDate(), user.getJob()));
+        Diary diary = diaryRepository.save(saveBaseDiary(user, Worktype.DAY_OFF, LocalDate.parse(updateBaseDiaryRequest.getDate()), user.getJob()));
         return new GetDiaryIdResponse(diary.getId());
     }
 
@@ -58,7 +58,7 @@ public class DiaryService {
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createCaddyDiaryRequest.getWorktype()), createCaddyDiaryRequest.getMemo(),
                 imageUrlList, createCaddyDiaryRequest.getIncome(), createCaddyDiaryRequest.getExpenditure(),
-                createCaddyDiaryRequest.getSaving(), createCaddyDiaryRequest.getDate(), user.getJob());
+                createCaddyDiaryRequest.getSaving(), LocalDate.parse(createCaddyDiaryRequest.getDate()), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Caddy caddy = Caddy.builder()
                 .diary(savedDiary)
@@ -77,7 +77,7 @@ public class DiaryService {
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createRiderDiaryRequest.getWorktype()), createRiderDiaryRequest.getMemo(),
                 imageUrlList, createRiderDiaryRequest.getIncome(), createRiderDiaryRequest.getExpenditure(),
-                createRiderDiaryRequest.getSaving(), createRiderDiaryRequest.getDate(), user.getJob());
+                createRiderDiaryRequest.getSaving(), LocalDate.parse(createRiderDiaryRequest.getDate()), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Rider rider = Rider.builder()
                 .diary(savedDiary)
@@ -96,7 +96,7 @@ public class DiaryService {
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createDayworkerDiaryRequest.getWorktype()), createDayworkerDiaryRequest.getMemo(),
                 imageUrlList, createDayworkerDiaryRequest.getIncome(), createDayworkerDiaryRequest.getExpenditure(),
-                createDayworkerDiaryRequest.getSaving(), createDayworkerDiaryRequest.getDate(), user.getJob());
+                createDayworkerDiaryRequest.getSaving(), LocalDate.parse(createDayworkerDiaryRequest.getDate()), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Dayworker dayworker = Dayworker.builder()
                 .diary(savedDiary)

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -387,6 +387,8 @@ public class DiaryService {
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.DIARY_NOT_FOUND_ERROR));
         if (!diary.getUser().equals(user))
             throw new BaseException(BaseResponseStatus.DIARY_USER_NOT_MATCH_ERROR);
+        if (diary.getWorktype().equals(Worktype.DAY_OFF))
+            throw new BaseException(BaseResponseStatus.CANT_BOAST_DIARY_ERROR);
 
         return getBoastDiaryResponseByJob(user.getJob(), diary);
     }
@@ -466,22 +468,14 @@ public class DiaryService {
     }
 
     private Object getDiaryDetailsSplitByCase(String jobTitle, Diary diary, Boolean hasId) {
-        if (diary.getWorktype().equals(Worktype.DAY_OFF)) {
-            if (hasId) {
-                return GetDayOffDiaryDetailsResponse.builder()
-                        .worktype(Worktype.DAY_OFF.getValue())
-                        .build();
-            }
-            return GetDayOffDiaryDetailsResponse.builder()
-                    .id(diary.getId())
-                    .worktype(Worktype.DAY_OFF.getValue())
-                    .build();
-        }
+        if (diary.getWorktype().equals(Worktype.DAY_OFF))
+            return getDefaultDiaryDetails(jobTitle, diary, hasId);
 
         if (Job.CADDY.getTitle().equals(jobTitle.replace(" ", ""))) {
             if (hasId) {
                 return GetCaddyDiaryDetailsResponse.builder()
                         .worktype(diary.getWorktype().getValue())
+                        .date(diary.getWorkAt().toString())
                         .memo(diary.getMemo())
                         .imageUrlList(diary.getImage())
                         .income(diary.getIncome())
@@ -496,6 +490,7 @@ public class DiaryService {
             return GetCaddyDiaryDetailsResponse.builder()
                     .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
+                    .date(diary.getWorkAt().toString())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())
                     .income(diary.getIncome())
@@ -510,6 +505,7 @@ public class DiaryService {
             if (hasId) {
                 return GetRiderDiaryDetailsResponse.builder()
                         .worktype(diary.getWorktype().getValue())
+                        .date(diary.getWorkAt().toString())
                         .memo(diary.getMemo())
                         .imageUrlList(diary.getImage())
                         .income(diary.getIncome())
@@ -524,6 +520,7 @@ public class DiaryService {
             return GetRiderDiaryDetailsResponse.builder()
                     .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
+                    .date(diary.getWorkAt().toString())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())
                     .income(diary.getIncome())
@@ -538,6 +535,7 @@ public class DiaryService {
             if (hasId) {
                 return GetDayworkerDiaryDetailsResponse.builder()
                         .worktype(diary.getWorktype().getValue())
+                        .date(diary.getWorkAt().toString())
                         .memo(diary.getMemo())
                         .imageUrlList(diary.getImage())
                         .income(diary.getIncome())
@@ -552,6 +550,7 @@ public class DiaryService {
             return GetDayworkerDiaryDetailsResponse.builder()
                     .id(diary.getId())
                     .worktype(diary.getWorktype().getValue())
+                    .date(diary.getWorkAt().toString())
                     .memo(diary.getMemo())
                     .imageUrlList(diary.getImage())
                     .income(diary.getIncome())
@@ -561,6 +560,101 @@ public class DiaryService {
                     .dailyWage(diary.getDayworker().getDailyWage())
                     .typeOfJob(diary.getDayworker().getTypeOfJob())
                     .numberOfWork(diary.getDayworker().getNumberOfWork())
+                    .build();
+        }
+        throw new BaseException(BaseResponseStatus.JOB_NOT_FOUND_ERROR);
+    }
+
+    private Object getDefaultDiaryDetails(String jobTitle, Diary diary, Boolean hasId) {
+        if (Job.CADDY.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetCaddyDiaryDetailsResponse.builder()
+                        .worktype(Worktype.DAY_OFF.getValue())
+                        .date(diary.getWorkAt().toString())
+                        .memo("")
+                        .imageUrlList(new ArrayList<>())
+                        .income(0L)
+                        .expenditure(0L)
+                        .saving(0L)
+                        .rounding(0L)
+                        .caddyFee(0L)
+                        .overFee(0L)
+                        .topdressing(false)
+                        .build();
+            }
+            return GetCaddyDiaryDetailsResponse.builder()
+                    .id(diary.getId())
+                    .worktype(Worktype.DAY_OFF.getValue())
+                    .date(diary.getWorkAt().toString())
+                    .memo("")
+                    .imageUrlList(new ArrayList<>())
+                    .income(0L)
+                    .expenditure(0L)
+                    .saving(0L)
+                    .rounding(0L)
+                    .caddyFee(0L)
+                    .overFee(0L)
+                    .topdressing(false)
+                    .build();
+        } else if (Job.RIDER.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetRiderDiaryDetailsResponse.builder()
+                        .worktype(Worktype.DAY_OFF.getValue())
+                        .date(diary.getWorkAt().toString())
+                        .memo("")
+                        .imageUrlList(new ArrayList<>())
+                        .income(0L)
+                        .expenditure(0L)
+                        .saving(0L)
+                        .incomeOfDeliveries(0L)
+                        .numberOfDeliveries(0L)
+                        .incomeOfPromotions(0L)
+                        .numberOfPromotions(0L)
+                        .build();
+            }
+            return GetRiderDiaryDetailsResponse.builder()
+                    .id(diary.getId())
+                    .worktype(Worktype.DAY_OFF.getValue())
+                    .date(diary.getWorkAt().toString())
+                    .memo("")
+                    .imageUrlList(new ArrayList<>())
+                    .income(0L)
+                    .expenditure(0L)
+                    .saving(0L)
+                    .incomeOfDeliveries(0L)
+                    .numberOfDeliveries(0L)
+                    .incomeOfPromotions(0L)
+                    .numberOfPromotions(0L)
+                    .build();
+        } else if (Job.DAYWORKER.getTitle().equals(jobTitle.replace(" ", ""))) {
+            if (hasId) {
+                return GetDayworkerDiaryDetailsResponse.builder()
+                        .worktype(Worktype.DAY_OFF.getValue())
+                        .date(diary.getWorkAt().toString())
+                        .memo("")
+                        .imageUrlList(new ArrayList<>())
+                        .income(0L)
+                        .expenditure(0L)
+                        .saving(0L)
+                        .place("")
+                        .dailyWage(0L)
+                        .typeOfJob("")
+                        .numberOfWork(0.0)
+                        .build();
+            }
+            return GetDayworkerDiaryDetailsResponse.builder()
+                    .id(diary.getId())
+                    .worktype(Worktype.DAY_OFF.getValue())
+                    .date(diary.getWorkAt().toString())
+                    .memo("")
+                    .imageUrlList(new ArrayList<>())
+                    .income(0L)
+                    .expenditure(0L)
+                    .saving(0L)
+                    .place("")
+                    .dailyWage(0L)
+                    .typeOfJob("")
+                    .numberOfWork(0.0)
                     .build();
         }
         throw new BaseException(BaseResponseStatus.JOB_NOT_FOUND_ERROR);

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -49,12 +49,14 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveDayOffDiary(UserDetails userDetails, UpdateBaseDiaryRequest updateBaseDiaryRequest) {
         User user = userFindService.findByUserDetails(userDetails);
+        isValidDate(user, LocalDate.parse(updateBaseDiaryRequest.getDate()));
         Diary diary = diaryRepository.save(saveBaseDiary(user, Worktype.DAY_OFF, LocalDate.parse(updateBaseDiaryRequest.getDate()), user.getJob()));
         return new GetDiaryIdResponse(diary.getId());
     }
 
     public GetDiaryIdResponse saveCaddyDiary(UserDetails userDetails, UpdateCaddyDiaryRequest createCaddyDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
+        isValidDate(user, LocalDate.parse(createCaddyDiaryRequest.getDate()));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createCaddyDiaryRequest.getWorktype()), createCaddyDiaryRequest.getMemo(),
                 imageUrlList, createCaddyDiaryRequest.getIncome(), createCaddyDiaryRequest.getExpenditure(),
@@ -74,6 +76,7 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveRiderDiary(UserDetails userDetails, UpdateRiderDiaryRequest createRiderDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
+        isValidDate(user, LocalDate.parse(createRiderDiaryRequest.getDate()));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createRiderDiaryRequest.getWorktype()), createRiderDiaryRequest.getMemo(),
                 imageUrlList, createRiderDiaryRequest.getIncome(), createRiderDiaryRequest.getExpenditure(),
@@ -93,6 +96,7 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveDayworkerDiary(UserDetails userDetails, UpdateDayworkerDiaryRequest createDayworkerDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
+        isValidDate(user, LocalDate.parse(createDayworkerDiaryRequest.getDate()));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createDayworkerDiaryRequest.getWorktype()), createDayworkerDiaryRequest.getMemo(),
                 imageUrlList, createDayworkerDiaryRequest.getIncome(), createDayworkerDiaryRequest.getExpenditure(),
@@ -559,5 +563,10 @@ public class DiaryService {
                     .build();
         }
         throw new BaseException(BaseResponseStatus.JOB_NOT_FOUND_ERROR);
+    }
+
+    private void isValidDate(User user, LocalDate date) {
+        if (diaryRepository.existsByUserAndWorkAtAndJob(user, date, user.getJob()))
+            throw new BaseException(BaseResponseStatus.DIARY_ALREADY_EXISTS_ERROR);
     }
 }

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -28,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,18 +50,18 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveDayOffDiary(UserDetails userDetails, UpdateBaseDiaryRequest updateBaseDiaryRequest) {
         User user = userFindService.findByUserDetails(userDetails);
-        isValidDate(user, LocalDate.parse(updateBaseDiaryRequest.getDate()));
-        Diary diary = diaryRepository.save(saveBaseDiary(user, Worktype.DAY_OFF, LocalDate.parse(updateBaseDiaryRequest.getDate()), user.getJob()));
+        isValidDate(user, LocalDate.parse(updateBaseDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")));
+        Diary diary = diaryRepository.save(saveBaseDiary(user, Worktype.DAY_OFF, LocalDate.parse(updateBaseDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")), user.getJob()));
         return new GetDiaryIdResponse(diary.getId());
     }
 
     public GetDiaryIdResponse saveCaddyDiary(UserDetails userDetails, UpdateCaddyDiaryRequest createCaddyDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
-        isValidDate(user, LocalDate.parse(createCaddyDiaryRequest.getDate()));
+        isValidDate(user, LocalDate.parse(createCaddyDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createCaddyDiaryRequest.getWorktype()), createCaddyDiaryRequest.getMemo(),
                 imageUrlList, createCaddyDiaryRequest.getIncome(), createCaddyDiaryRequest.getExpenditure(),
-                createCaddyDiaryRequest.getSaving(), LocalDate.parse(createCaddyDiaryRequest.getDate()), user.getJob());
+                createCaddyDiaryRequest.getSaving(), LocalDate.parse(createCaddyDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Caddy caddy = Caddy.builder()
                 .diary(savedDiary)
@@ -76,11 +77,11 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveRiderDiary(UserDetails userDetails, UpdateRiderDiaryRequest createRiderDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
-        isValidDate(user, LocalDate.parse(createRiderDiaryRequest.getDate()));
+        isValidDate(user, LocalDate.parse(createRiderDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createRiderDiaryRequest.getWorktype()), createRiderDiaryRequest.getMemo(),
                 imageUrlList, createRiderDiaryRequest.getIncome(), createRiderDiaryRequest.getExpenditure(),
-                createRiderDiaryRequest.getSaving(), LocalDate.parse(createRiderDiaryRequest.getDate()), user.getJob());
+                createRiderDiaryRequest.getSaving(), LocalDate.parse(createRiderDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Rider rider = Rider.builder()
                 .diary(savedDiary)
@@ -96,11 +97,11 @@ public class DiaryService {
 
     public GetDiaryIdResponse saveDayworkerDiary(UserDetails userDetails, UpdateDayworkerDiaryRequest createDayworkerDiaryRequest, List<MultipartFile> multipartFileList) {
         User user = userFindService.findByUserDetails(userDetails);
-        isValidDate(user, LocalDate.parse(createDayworkerDiaryRequest.getDate()));
+        isValidDate(user, LocalDate.parse(createDayworkerDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")));
         List<String> imageUrlList = uploadDiaryImage(multipartFileList);
         Diary diary = saveDiary(user, Worktype.findByValue(createDayworkerDiaryRequest.getWorktype()), createDayworkerDiaryRequest.getMemo(),
                 imageUrlList, createDayworkerDiaryRequest.getIncome(), createDayworkerDiaryRequest.getExpenditure(),
-                createDayworkerDiaryRequest.getSaving(), LocalDate.parse(createDayworkerDiaryRequest.getDate()), user.getJob());
+                createDayworkerDiaryRequest.getSaving(), LocalDate.parse(createDayworkerDiaryRequest.getDate(), DateTimeFormatter.ofPattern("yyyy-M-d")), user.getJob());
         Diary savedDiary = diaryRepository.save(diary);
         Dayworker dayworker = Dayworker.builder()
                 .diary(savedDiary)

--- a/src/main/java/blueclub/server/global/annotation/LocalDatePattern.java
+++ b/src/main/java/blueclub/server/global/annotation/LocalDatePattern.java
@@ -1,0 +1,24 @@
+package blueclub.server.global.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Constraint(validatedBy = {LocalDatePatternValidator.class})
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+public @interface LocalDatePattern {
+
+    String message() default "날짜 형식이 맞지 않습니다.";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    String pattern() default "yyyy-MM-dd";
+}

--- a/src/main/java/blueclub/server/global/annotation/LocalDatePattern.java
+++ b/src/main/java/blueclub/server/global/annotation/LocalDatePattern.java
@@ -20,5 +20,5 @@ public @interface LocalDatePattern {
 
     Class<? extends Payload>[] payload() default { };
 
-    String pattern() default "yyyy-MM-dd";
+    String pattern() default "yyyy-M-d";
 }

--- a/src/main/java/blueclub/server/global/annotation/LocalDatePatternValidator.java
+++ b/src/main/java/blueclub/server/global/annotation/LocalDatePatternValidator.java
@@ -27,8 +27,8 @@ public class LocalDatePatternValidator implements ConstraintValidator<LocalDateP
             }
             return true;
         }
-        try{
-            // yyyy-MM
+        // yyyy-MM
+        try {
             YearMonth yearMonth = YearMonth.parse(value, DateTimeFormatter.ofPattern(this.pattern));
         } catch (Exception e) {
             return false;

--- a/src/main/java/blueclub/server/global/annotation/LocalDatePatternValidator.java
+++ b/src/main/java/blueclub/server/global/annotation/LocalDatePatternValidator.java
@@ -1,0 +1,38 @@
+package blueclub.server.global.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDatePatternValidator implements ConstraintValidator<LocalDatePattern, String> {
+
+    private String pattern;
+
+    @Override
+    public void initialize(LocalDatePattern constraintAnnotation) {
+        this.pattern = constraintAnnotation.pattern();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // yyyy-MM-dd
+        if (value.length() > 7) {
+            try {
+                LocalDate localDate = LocalDate.parse(value, DateTimeFormatter.ofPattern(this.pattern));
+            } catch (Exception e) {
+                return false;
+            }
+            return true;
+        }
+        try{
+            // yyyy-MM
+            YearMonth yearMonth = YearMonth.parse(value, DateTimeFormatter.ofPattern(this.pattern));
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -54,6 +54,7 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     DIARY_USER_NOT_MATCH_ERROR(HttpStatus.NOT_FOUND, "DIARY_003", "사용자의 근무 일지가 아닙니다."),
     JOB_USER_NOT_MATCH_ERROR(HttpStatus.NOT_FOUND, "DIARY_004", "입력하신 직업과 사용자의 직업이 일치하지 않습니다."),
     DIARY_ALREADY_EXISTS_ERROR(HttpStatus.NOT_FOUND, "DIARY_005", "이미 근무 일지가 존재하는 날짜입니다."),
+    CANT_BOAST_DIARY_ERROR(HttpStatus.BAD_REQUEST, "DIARY_006", "해당 근무 일지는 자랑하기 기능을 이용할 수 없습니다."),
 
     // Notice
     NOTICE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "NOTICE_001", "존재하지 않는 공지입니다."),

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -53,6 +53,7 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     DIARY_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "DIARY_002", "존재하지 않는 근무 일지입니다."),
     DIARY_USER_NOT_MATCH_ERROR(HttpStatus.NOT_FOUND, "DIARY_003", "사용자의 근무 일지가 아닙니다."),
     JOB_USER_NOT_MATCH_ERROR(HttpStatus.NOT_FOUND, "DIARY_004", "입력하신 직업과 사용자의 직업이 일치하지 않습니다."),
+    DIARY_ALREADY_EXISTS_ERROR(HttpStatus.NOT_FOUND, "DIARY_005", "이미 근무 일지가 존재하는 날짜입니다."),
 
     // Notice
     NOTICE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "NOTICE_001", "존재하지 않는 공지입니다."),

--- a/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
+++ b/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 
 @PreAuthorize("hasRole('USER')")
 @Validated
@@ -41,6 +42,6 @@ public class MonthlyGoalController {
             @PathVariable("yearMonth")
             String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(monthlyGoalService.getMonthlyGoalAndProgress(userDetails, YearMonth.parse(yearMonth)));
+        return BaseResponse.toResponseEntityContainsResult(monthlyGoalService.getMonthlyGoalAndProgress(userDetails, YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-M"))));
     }
 }

--- a/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
+++ b/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
@@ -1,12 +1,12 @@
 package blueclub.server.monthlyGoal.controller;
 
+import blueclub.server.global.annotation.LocalDatePattern;
 import blueclub.server.global.response.BaseResponse;
 import blueclub.server.global.response.BaseResponseStatus;
 import blueclub.server.monthlyGoal.dto.request.UpdateMonthlyGoalRequest;
 import blueclub.server.monthlyGoal.service.MonthlyGoalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,8 +37,10 @@ public class MonthlyGoalController {
     @GetMapping("/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyGoalAndProgress(
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable("yearMonth") @DateTimeFormat(pattern = "yyyy-mm") YearMonth yearMonth
+            @LocalDatePattern(pattern = "yyyy-MM")
+            @PathVariable("yearMonth")
+            String yearMonth
     ) {
-        return BaseResponse.toResponseEntityContainsResult(monthlyGoalService.getMonthlyGoalAndProgress(userDetails, yearMonth));
+        return BaseResponse.toResponseEntityContainsResult(monthlyGoalService.getMonthlyGoalAndProgress(userDetails, YearMonth.parse(yearMonth)));
     }
 }

--- a/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
+++ b/src/main/java/blueclub/server/monthlyGoal/controller/MonthlyGoalController.java
@@ -37,7 +37,7 @@ public class MonthlyGoalController {
     @GetMapping("/{yearMonth}")
     public ResponseEntity<BaseResponse> getMonthlyGoalAndProgress(
             @AuthenticationPrincipal UserDetails userDetails,
-            @LocalDatePattern(pattern = "yyyy-MM")
+            @LocalDatePattern(pattern = "yyyy-M")
             @PathVariable("yearMonth")
             String yearMonth
     ) {

--- a/src/main/java/blueclub/server/monthlyGoal/dto/request/UpdateMonthlyGoalRequest.java
+++ b/src/main/java/blueclub/server/monthlyGoal/dto/request/UpdateMonthlyGoalRequest.java
@@ -1,16 +1,14 @@
 package blueclub.server.monthlyGoal.dto.request;
 
+import blueclub.server.global.annotation.LocalDatePattern;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.YearMonth;
 
 @Builder
 public record UpdateMonthlyGoalRequest (
-        @DateTimeFormat(pattern = "yyyy-mm")
-        YearMonth yearMonth,
+        @LocalDatePattern(pattern = "yyyy-MM")
+        String yearMonth,
         @Min(value = 100000, message = "월 수입 목표는 10만원 이상으로 입력해주세요")
         @Max(value = 99990000, message = "월 수입 목표는 9999만원 이하로 입력해주세요")
         Long monthlyTargetIncome

--- a/src/main/java/blueclub/server/monthlyGoal/dto/request/UpdateMonthlyGoalRequest.java
+++ b/src/main/java/blueclub/server/monthlyGoal/dto/request/UpdateMonthlyGoalRequest.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record UpdateMonthlyGoalRequest (
-        @LocalDatePattern(pattern = "yyyy-MM")
+        @LocalDatePattern(pattern = "yyyy-M")
         String yearMonth,
         @Min(value = 100000, message = "월 수입 목표는 10만원 이상으로 입력해주세요")
         @Max(value = 99990000, message = "월 수입 목표는 9999만원 이하로 입력해주세요")

--- a/src/main/java/blueclub/server/monthlyGoal/service/MonthlyGoalService.java
+++ b/src/main/java/blueclub/server/monthlyGoal/service/MonthlyGoalService.java
@@ -28,12 +28,12 @@ public class MonthlyGoalService {
 
     public void updateMonthlyGoal(UserDetails userDetails, UpdateMonthlyGoalRequest updateMonthlyGoalRequest) {
         User user = userFindService.findByUserDetails(userDetails);
-        Optional<MonthlyGoal> monthlyGoal = monthlyGoalRepository.findByUserAndYearMonth(user, updateMonthlyGoalRequest.yearMonth());
+        Optional<MonthlyGoal> monthlyGoal = monthlyGoalRepository.findByUserAndYearMonth(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth()));
         if (monthlyGoal.isPresent()) {
             monthlyGoal.get().updateMonthlyGoal(updateMonthlyGoalRequest.monthlyTargetIncome());
             return;
         }
-        saveMonthlyGoal(user, updateMonthlyGoalRequest.yearMonth(), updateMonthlyGoalRequest.monthlyTargetIncome());
+        saveMonthlyGoal(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth()), updateMonthlyGoalRequest.monthlyTargetIncome());
     }
 
     public GetMonthlyGoalResponse getMonthlyGoalAndProgress(UserDetails userDetails, YearMonth yearMonth) {

--- a/src/main/java/blueclub/server/monthlyGoal/service/MonthlyGoalService.java
+++ b/src/main/java/blueclub/server/monthlyGoal/service/MonthlyGoalService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 @Service
@@ -28,12 +29,12 @@ public class MonthlyGoalService {
 
     public void updateMonthlyGoal(UserDetails userDetails, UpdateMonthlyGoalRequest updateMonthlyGoalRequest) {
         User user = userFindService.findByUserDetails(userDetails);
-        Optional<MonthlyGoal> monthlyGoal = monthlyGoalRepository.findByUserAndYearMonth(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth()));
+        Optional<MonthlyGoal> monthlyGoal = monthlyGoalRepository.findByUserAndYearMonth(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth(), DateTimeFormatter.ofPattern("yyyy-M")));
         if (monthlyGoal.isPresent()) {
             monthlyGoal.get().updateMonthlyGoal(updateMonthlyGoalRequest.monthlyTargetIncome());
             return;
         }
-        saveMonthlyGoal(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth()), updateMonthlyGoalRequest.monthlyTargetIncome());
+        saveMonthlyGoal(user, YearMonth.parse(updateMonthlyGoalRequest.yearMonth(), DateTimeFormatter.ofPattern("yyyy-M")), updateMonthlyGoalRequest.monthlyTargetIncome());
     }
 
     public GetMonthlyGoalResponse getMonthlyGoalAndProgress(UserDetails userDetails, YearMonth yearMonth) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,7 +8,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: false

--- a/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
@@ -6,6 +6,8 @@ import blueclub.server.diary.dto.request.UpdateBaseDiaryRequest;
 import blueclub.server.diary.dto.request.UpdateCaddyDiaryRequest;
 import blueclub.server.diary.dto.response.*;
 import blueclub.server.global.ControllerTest;
+import blueclub.server.global.response.BaseException;
+import blueclub.server.global.response.BaseResponseStatus;
 import blueclub.server.user.domain.Job;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -34,8 +36,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resour
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -356,6 +357,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -407,6 +409,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -458,6 +461,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -469,48 +473,6 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.numberOfWork").type(NUMBER).description("[DEFAULT 0.0] 공수")
                                             )
                                             .responseSchema(Schema.schema("GetDayworkerDiaryDetailsResponse"))
-                                            .build()
-                            )
-                    ));
-        }
-
-        @Test
-        @DisplayName("휴무 근무 일지 상세조회에 성공한다")
-        void getDayOffDiaryDetailsSuccess() throws Exception {
-            // given
-            doReturn(getDayOffDiaryDetailsResponse())
-                    .when(diaryService)
-                    .getDiaryDetails(any(), anyString(), anyLong());
-
-            // when
-            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
-                    .get(BASE_URL, 1L)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
-                    .queryParam(JOB, CADDY);
-
-            // then
-            mockMvc.perform(requestBuilder)
-                    .andExpect(status().isOk())
-                    .andDo(document(
-                            "GetDayOffDiaryDetails",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            resource(
-                                    ResourceSnippetParameters.builder()
-                                            .tag("Diary API")
-                                            .summary("근무 일지 상세조회 API")
-                                            .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
-                                            )
-                                            .pathParameters(
-                                                    parameterWithName("diaryId").description("근무 일지 ID")
-                                            )
-                                            .responseFields(
-                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
-                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
-                                                    fieldWithPath("result.worktype").type(STRING).description("근무 형태")
-                                            )
-                                            .responseSchema(Schema.schema("GetDayOffDiaryDetailsResponse"))
                                             .build()
                             )
                     ));
@@ -557,6 +519,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -608,6 +571,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -658,6 +622,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
                                                     fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
                                                     fieldWithPath("result.worktype").type(STRING).description("근무 형태"),
+                                                    fieldWithPath("result.date").type(STRING).description("근무 일자"),
                                                     fieldWithPath("result.memo").type(STRING).description("[DEFAULT NULL] 메모"),
                                                     fieldWithPath("result.imageUrlList[]").type(ARRAY).description("사진 URL 리스트"),
                                                     fieldWithPath("result.income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
@@ -675,49 +640,7 @@ public class DiaryControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("날짜로 휴무 근무 일지 상세조회에 성공한다")
-        void getDayOffDiaryDetailsSuccess() throws Exception {
-            // given
-            doReturn(getDayOffDiaryDetailsByDateResponse())
-                    .when(diaryService)
-                    .getDiaryDetailsByDate(any(), anyString(), any(LocalDate.class));
-
-            // when
-            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
-                    .get(BASE_URL)
-                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN)
-                    .queryParam(JOB, CADDY)
-                    .queryParam(DATE, TARGET_DATE);
-
-            // then
-            mockMvc.perform(requestBuilder)
-                    .andExpect(status().isOk())
-                    .andDo(document(
-                            "GetDayOffDiaryDetailsByDate",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            resource(
-                                    ResourceSnippetParameters.builder()
-                                            .tag("Diary API")
-                                            .summary("날짜로 근무 일지 상세조회 API")
-                                            .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"),
-                                                    parameterWithName("date").description("날짜 // 형식 : yyyy-mm-dd")
-                                            )
-                                            .responseFields(
-                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
-                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
-                                                    fieldWithPath("result.id").type(NUMBER).description("근무 일지 ID"),
-                                                    fieldWithPath("result.worktype").type(STRING).description("근무 형태")
-                                            )
-                                            .responseSchema(Schema.schema("GetDayOffDiaryDetailsByDateResponse"))
-                                            .build()
-                            )
-                    ));
-        }
-
-        @Test
-        @DisplayName("입력한 날짜의 휴무 근무 일지가 없다면 결과로 null을 반환한다")
+        @DisplayName("입력한 날짜의 근무 일지가 없다면 결과로 null을 반환한다")
         void getNotFoundDiaryDetailsSuccess() throws Exception {
             // given
             doReturn(null)
@@ -989,6 +912,44 @@ public class DiaryControllerTest extends ControllerTest {
                             )
                     ));
         }
+
+        @Test
+        @DisplayName("휴무일인 근무 일지는 자랑하기 상세조회에 실패한다")
+        void throwExceptionByDayOffDiary() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.CANT_BOAST_DIARY_ERROR))
+                    .when(diaryService)
+                    .getBoastDiary(any(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL, 1)
+                    .header(AUTHORIZATION, BEARER, ACCESS_TOKEN);
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isBadRequest())
+                    .andDo(document(
+                            "GetBoastDiaryDayOffError",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("Diary API")
+                                            .summary("자랑하기 상세조회 API")
+                                            .pathParameters(
+                                                    parameterWithName("diaryId").description("근무 일지 ID")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                    fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                    fieldWithPath("result").type(NULL).description("null 반환")
+                                            )
+                                            .responseSchema(Schema.schema("BaseResponse"))
+                                            .build()
+                            )
+                    ));
+        }
     }
 
     private UpdateCaddyDiaryRequest updateCaddyDiaryRequest() {
@@ -998,7 +959,7 @@ public class DiaryControllerTest extends ControllerTest {
                 .income(CADDY_DIARY.getIncome())
                 .expenditure(CADDY_DIARY.getExpenditure())
                 .saving(CADDY_DIARY.getSaving())
-                .date(CADDY_DIARY.getDate())
+                .date(CADDY_DIARY.getDate().toString())
                 .imageUrlList(CADDY_DIARY.getImageUrlList())
                 .rounding(CADDY_DIARY.getRounding())
                 .caddyFee(CADDY_DIARY.getCaddyFee())
@@ -1010,13 +971,14 @@ public class DiaryControllerTest extends ControllerTest {
     private UpdateBaseDiaryRequest updateBaseDiaryRequest() {
         return UpdateBaseDiaryRequest.builder()
                 .worktype(Worktype.DAY_OFF.getValue())
-                .date(CADDY_DIARY.getDate())
+                .date(CADDY_DIARY.getDate().toString())
                 .build();
     }
 
     private GetCaddyDiaryDetailsResponse getCaddyDiaryDetailsResponse() {
         return GetCaddyDiaryDetailsResponse.builder()
                 .worktype(CADDY_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(CADDY_DIARY.getMemo())
                 .imageUrlList(CADDY_DIARY.getImageUrlList())
                 .income(CADDY_DIARY.getIncome())
@@ -1032,6 +994,7 @@ public class DiaryControllerTest extends ControllerTest {
     private GetRiderDiaryDetailsResponse getRiderDiaryDetailsResponse() {
         return GetRiderDiaryDetailsResponse.builder()
                 .worktype(RIDER_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(RIDER_DIARY.getMemo())
                 .imageUrlList(RIDER_DIARY.getImageUrlList())
                 .income(RIDER_DIARY.getIncome())
@@ -1047,6 +1010,7 @@ public class DiaryControllerTest extends ControllerTest {
     private GetDayworkerDiaryDetailsResponse getDayworkerDiaryDetailsResponse() {
         return GetDayworkerDiaryDetailsResponse.builder()
                 .worktype(DAYWORKER_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(DAYWORKER_DIARY.getMemo())
                 .imageUrlList(DAYWORKER_DIARY.getImageUrlList())
                 .income(DAYWORKER_DIARY.getIncome())
@@ -1059,16 +1023,11 @@ public class DiaryControllerTest extends ControllerTest {
                 .build();
     }
 
-    private GetDayOffDiaryDetailsResponse getDayOffDiaryDetailsResponse() {
-        return GetDayOffDiaryDetailsResponse.builder()
-                .worktype(Worktype.DAY_OFF.getValue())
-                .build();
-    }
-
     private GetCaddyDiaryDetailsResponse getCaddyDiaryDetailsByDateResponse() {
         return GetCaddyDiaryDetailsResponse.builder()
                 .id(DAYWORKER_DIARY.getId())
                 .worktype(CADDY_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(CADDY_DIARY.getMemo())
                 .imageUrlList(CADDY_DIARY.getImageUrlList())
                 .income(CADDY_DIARY.getIncome())
@@ -1085,6 +1044,7 @@ public class DiaryControllerTest extends ControllerTest {
         return GetRiderDiaryDetailsResponse.builder()
                 .id(DAYWORKER_DIARY.getId())
                 .worktype(RIDER_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(RIDER_DIARY.getMemo())
                 .imageUrlList(RIDER_DIARY.getImageUrlList())
                 .income(RIDER_DIARY.getIncome())
@@ -1101,6 +1061,7 @@ public class DiaryControllerTest extends ControllerTest {
         return GetDayworkerDiaryDetailsResponse.builder()
                 .id(DAYWORKER_DIARY.getId())
                 .worktype(DAYWORKER_DIARY.getWorktype())
+                .date(CADDY_DIARY.getDate().toString())
                 .memo(DAYWORKER_DIARY.getMemo())
                 .imageUrlList(DAYWORKER_DIARY.getImageUrlList())
                 .income(DAYWORKER_DIARY.getIncome())
@@ -1110,13 +1071,6 @@ public class DiaryControllerTest extends ControllerTest {
                 .dailyWage(DAYWORKER_DIARY.getDailyWage())
                 .typeOfJob(DAYWORKER_DIARY.getTypeOfJob())
                 .numberOfWork(DAYWORKER_DIARY.getNumberOfWork())
-                .build();
-    }
-
-    private GetDayOffDiaryDetailsResponse getDayOffDiaryDetailsByDateResponse() {
-        return GetDayOffDiaryDetailsResponse.builder()
-                .id(DAYWORKER_DIARY.getId())
-                .worktype(Worktype.DAY_OFF.getValue())
                 .build();
     }
 

--- a/src/test/java/blueclub/server/monthlyGoal/controller/MonthlyGoalControllerTest.java
+++ b/src/test/java/blueclub/server/monthlyGoal/controller/MonthlyGoalControllerTest.java
@@ -1,8 +1,6 @@
 package blueclub.server.monthlyGoal.controller;
 
 import blueclub.server.global.ControllerTest;
-import blueclub.server.global.response.BaseException;
-import blueclub.server.global.response.BaseResponseStatus;
 import blueclub.server.monthlyGoal.dto.request.UpdateMonthlyGoalRequest;
 import blueclub.server.monthlyGoal.dto.response.GetMonthlyGoalResponse;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -14,15 +12,14 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import java.time.YearMonth;
-
 import static blueclub.server.fixture.JwtTokenFixture.ACCESS_TOKEN;
 import static blueclub.server.fixture.JwtTokenFixture.BEARER;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -130,7 +127,7 @@ public class MonthlyGoalControllerTest extends ControllerTest {
 
     private UpdateMonthlyGoalRequest updateMonthlyGoalRequest() {
         return UpdateMonthlyGoalRequest.builder()
-                .yearMonth(YearMonth.parse("2024-01"))
+                .yearMonth("2024-01")
                 .monthlyTargetIncome(200000L)
                 .build();
     }


### PR DESCRIPTION
## Summary 📌
- 날짜 형식에 대해 커스텀 어노테이션으로 valid 판단
- 날짜 형식이 yyyy-M-d 와 같이 들어와도 yyyy-MM-dd로 정상적용되도록 변경
- 적용된 GET /list/{yearMonth} API 외에 모든 근무 기록 관련해 현재 직업 기준으로 적용하기로 결정
- 근무 일지 상세조회 등 최대한 같은 형식의 dto가 나오도록 통일
- 근무 일지 자랑하기 API에 누락된 예외상황 추가
## Describe your changes 📝
- LocalDate Valid custom annotation
- 날짜 형식 관련 로직 수정
- 근무 기록 관련 쿼리 수정
- 근무 일지 상세조회 response field에 date 추가
- 휴무일인 근무 일지의 자랑하기 조회 시에 대한 예외 처리
- 프론트 측 앱 릴리즈가 이루어져 있으므로, 버전 1.0.0 변경 및 db 초기화 >> 유지
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #112 