### PR TITLE
[Fix] #115 누락된 request 띄어쓰기 정책 통일 및 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '1.0.0-SNAPSHOT'
+version = '1.0.1-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "1.0.0"
+	version = "1.0.1"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }

--- a/src/main/java/blueclub/server/auth/service/AuthService.java
+++ b/src/main/java/blueclub/server/auth/service/AuthService.java
@@ -111,9 +111,6 @@ public class AuthService {
     }
 
     private User createUser(String socialId, SocialType socialType, String name, String nickname, String email, String phoneNumber, String profileImage) {
-        // 이메일 중복여부 체크
-        if (userRepository.existsByEmail(email))
-            throw new BaseException(BaseResponseStatus.DUPLICATED_EMAIL);
         // 닉네임 이모티콘, 특수기호 존재 시 삭제
         EmojiParser.removeAllEmojis(nickname);
         nickname = nickname.replaceAll("[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]", "");

--- a/src/main/java/blueclub/server/diary/controller/DiaryController.java
+++ b/src/main/java/blueclub/server/diary/controller/DiaryController.java
@@ -81,7 +81,7 @@ public class DiaryController {
             @NotBlank(message = "직업명은 필수입니다") @RequestParam("job") String jobTitle,
             @PathVariable("diaryId") Long diaryId
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetails(userDetails, jobTitle, diaryId));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetails(userDetails, jobTitle.replace(" ", ""), diaryId));
     }
 
     @GetMapping("")
@@ -94,7 +94,7 @@ public class DiaryController {
             @RequestParam("date")
             String date
     ) {
-        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle, LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-M-d"))));
+        return BaseResponse.toResponseEntityContainsResult(diaryService.getDiaryDetailsByDate(userDetails, jobTitle.replace(" ", ""), LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-M-d"))));
     }
 
     @DeleteMapping("/{diaryId}")

--- a/src/main/java/blueclub/server/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/blueclub/server/diary/repository/DiaryQueryRepository.java
@@ -11,7 +11,7 @@ public interface DiaryQueryRepository {
     Long getTotalMonthlyIncome(User user, YearMonth yearMonth);
     Integer getTotalWorkingDay(User user, YearMonth yearMonth);
     List<Diary> getMonthlyList(User user, YearMonth yearMonth);
-    List<Diary> getDiaryById(Long diaryId);
+    List<Diary> getDiaryById(User user, Long diaryId);
     List<Diary> getDiaryByDate(User user, LocalDate date);
     Integer getStraightWorkingDayLimitMonth(User user, LocalDate workAt);
     Boolean isRenew(User user, LocalDate workAt);

--- a/src/main/java/blueclub/server/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/blueclub/server/diary/repository/DiaryQueryRepositoryImpl.java
@@ -59,13 +59,15 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
     }
 
     @Override
-    public List<Diary> getDiaryById(Long diaryId) {
+    public List<Diary> getDiaryById(User user, Long diaryId) {
         return queryFactory
                 .selectDistinct(diary)
                 .from(diary)
                 .leftJoin(diary.image)
                 .fetchJoin()
-                .where(diary.id.eq(diaryId))
+                .where(diary.user.eq(user),
+                        diary.id.eq(diaryId),
+                        diary.job.eq(user.getJob()))
                 .fetch();
     }
 
@@ -76,7 +78,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
                 .from(diary)
                 .leftJoin(diary.image)
                 .fetchJoin()
-                .where(diary.workAt.eq(date),
+                .where(diary.user.eq(user),
+                        diary.workAt.eq(date),
                         diary.job.eq(user.getJob()))
                 .fetch();
     }

--- a/src/main/java/blueclub/server/diary/service/DiaryService.java
+++ b/src/main/java/blueclub/server/diary/service/DiaryService.java
@@ -265,10 +265,9 @@ public class DiaryService {
         if (!user.getJob().equals(Job.findByTitle(jobTitle)))
             throw new BaseException(BaseResponseStatus.JOB_USER_NOT_MATCH_ERROR);
 
-        List<Diary> diary = diaryRepository.getDiaryById(diaryId);
-        if (diary.isEmpty()) {
+        List<Diary> diary = diaryRepository.getDiaryById(user, diaryId);
+        if (diary.isEmpty())
             throw new BaseException(BaseResponseStatus.DIARY_NOT_FOUND_ERROR);
-        }
 
         return getDiaryDetailsSplitByCase(jobTitle, diary.get(0), true);
     }

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -39,7 +39,6 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_001", "이메일 형식이 올바르지 않습니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_002", "비밀번호 형식이 올바르지 않습니다."),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "AUTH_003", "해당 닉네임은 중복입니다."),
-    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "AUTH_004", "해당 이메일은 중복입니다."),
 
     // Member
     MEMBER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 사용자입니다."),

--- a/src/main/java/blueclub/server/user/domain/User.java
+++ b/src/main/java/blueclub/server/user/domain/User.java
@@ -7,7 +7,6 @@ import blueclub.server.global.entity.BaseTimeEntity;
 import blueclub.server.monthlyGoal.domain.MonthlyGoal;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +18,6 @@ import static jakarta.persistence.CascadeType.PERSIST;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = "email", name = "unique_email"))
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/blueclub/server/user/repository/UserRepository.java
+++ b/src/main/java/blueclub/server/user/repository/UserRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Boolean existsByNicknameAndRole(String nickname, Role role);
-    Boolean existsByEmail(String email);
     Optional<User> findBySocialId(String socialId);
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
     Boolean existsBySocialTypeAndSocialId(SocialType socialType, String socialId);

--- a/src/main/java/blueclub/server/user/service/UserService.java
+++ b/src/main/java/blueclub/server/user/service/UserService.java
@@ -1,5 +1,6 @@
 package blueclub.server.user.service;
 
+import blueclub.server.auth.domain.Role;
 import blueclub.server.auth.service.JwtService;
 import blueclub.server.global.response.BaseException;
 import blueclub.server.global.response.BaseResponseStatus;
@@ -35,6 +36,8 @@ public class UserService {
 
     public void addUserDetails(UserDetails userDetails, AddUserDetailsRequest addUserDetailsRequest) {
         User user = userFindService.findByUserDetails(userDetails);
+        if (userRepository.existsByNicknameAndRole(addUserDetailsRequest.nickname(), Role.USER))
+            throw new BaseException(BaseResponseStatus.DUPLICATED_NICKNAME);
         user.addDetails(
                 addUserDetailsRequest.nickname(),
                 Job.findByTitle(addUserDetailsRequest.job().replace(" ", "")),
@@ -46,6 +49,8 @@ public class UserService {
 
     public void updateUserDetails(UserDetails userDetails, UpdateUserDetailsRequest updateUserDetailsRequest) {
         User user = userFindService.findByUserDetails(userDetails);
+        if (!user.getNickname().equals(updateUserDetailsRequest.nickname()) && userRepository.existsByNicknameAndRole(updateUserDetailsRequest.nickname(), Role.USER))
+            throw new BaseException(BaseResponseStatus.DUPLICATED_NICKNAME);
         user.updateDetails(
                 updateUserDetailsRequest.nickname(),
                 Job.findByTitle(updateUserDetailsRequest.job().replace(" ", "")),


### PR DESCRIPTION
## Summary 📌
- Diary 관련 get API에서 request로 받은 job의 띄어쓰기 허용 정책 미적용 문제
- 일부 API들의 예외 미처리
- 다른 사용자의 근무 일지를 확인할 수 있는 문제
- 이메일 중복 정책 파기
## Describe your changes 📝
- job 띄어쓰기 허용하는 로직 추가
- 사용자 정보 추가 및 수정 시 닉네임 중복 예외 추가
- 다른 사용자의 근무 일지를 확인할 수 없도록 누락된 쿼리 수정
- 이메일 중복 정책 파기
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #115 