### PR TITLE
[Feat] #121 호출 제한 정책 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = 'blueclub'
-version = '1.0.3-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -43,7 +43,7 @@ openapi3 {
 	]
 	title = "BlueClub Swagger UI"
 	description = "BlueClub Spring REST Docs with Swagger UI."
-	version = "1.0.3"
+	version = "1.1.0"
 	format = "yaml"
 	outputFileNamePrefix = 'index'
 }
@@ -88,7 +88,7 @@ task swaggerConfig {
       parameters:
       - name: job
         in: query
-        description: "[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"
+        description: "[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 근로자)"
         required: true
         schema:
           type: string
@@ -204,7 +204,7 @@ task swaggerConfig {
     UpdateDayworkerDiaryRequest:
       title: UpdateDayworkerDiaryRequest
       type: object
-      description: 일용직 노동자 근무 일지 DTO
+      description: 일용직 근로자 근무 일지 DTO
       properties:
         worktype:
           type: string
@@ -348,6 +348,9 @@ dependencies {
 
 	// Emoji
 	implementation 'com.vdurmont:emoji-java:5.1.1'
+
+	// Rate Limit
+	implementation 'com.bucket4j:bucket4j-core:8.3.0'
 
 	compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.apache.commons:commons-collections4:4.0'

--- a/src/main/java/blueclub/server/auth/config/WebConfig.java
+++ b/src/main/java/blueclub/server/auth/config/WebConfig.java
@@ -1,11 +1,19 @@
 package blueclub.server.auth.config;
 
+import blueclub.server.global.config.RateLimitingInterceptor;
+import blueclub.server.user.service.UserFindService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final UserFindService userFindService;
+
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
@@ -13,4 +21,12 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "DELETE", "PATCH", "PUT", "OPTIONS")
                 .maxAge(3000);
     }
+
+    /*
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RateLimitingInterceptor(userFindService));
+    }
+
+     */
 }

--- a/src/main/java/blueclub/server/auth/config/WebConfig.java
+++ b/src/main/java/blueclub/server/auth/config/WebConfig.java
@@ -1,18 +1,13 @@
 package blueclub.server.auth.config;
 
 import blueclub.server.global.config.RateLimitingInterceptor;
-import blueclub.server.user.service.UserFindService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-
-    private final UserFindService userFindService;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -22,11 +17,9 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(3000);
     }
 
-    /*
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new RateLimitingInterceptor(userFindService));
+        registry.addInterceptor(new RateLimitingInterceptor());
     }
 
-     */
 }

--- a/src/main/java/blueclub/server/global/config/RateLimitingInterceptor.java
+++ b/src/main/java/blueclub/server/global/config/RateLimitingInterceptor.java
@@ -2,53 +2,52 @@ package blueclub.server.global.config;
 
 import blueclub.server.global.response.BaseException;
 import blueclub.server.global.response.BaseResponseStatus;
-import blueclub.server.user.domain.User;
-import blueclub.server.user.service.UserFindService;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/*
-@RequiredArgsConstructor
 public class RateLimitingInterceptor implements HandlerInterceptor {
 
-    private final UserFindService userFindService;
-    private final Map<String, Long> lastAccessMap = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> lastAccessMap = new ConcurrentHashMap<>();
+
+    private static final List<String> NO_CHECK_URL_LIST = List.of(
+            "/css", "/image", "/js", "/favicon.ico", "/swagger", "/docs", "/swagger-ui", "/v3/api-docs", "/error"); // Filter 작동 X
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String userId = getUserIdFromRequest(request); // 요청에서 accountId를 추출하는 로직을 구현해야 합니다.
-        synchronized (this) {
-            long now = System.currentTimeMillis();
-            long lastAccess = lastAccessMap.getOrDefault(userId, 0L);
-            long elapsedTime = now - lastAccess;
-            if (elapsedTime < 1000) { // 1초?당 1회로 제한
-                Thread.sleep(1000 - elapsedTime);
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        for (String NO_CHECK_URL: NO_CHECK_URL_LIST) {
+            if (request.getRequestURI().contains(NO_CHECK_URL)) {
+                return true;
             }
-            lastAccessMap.put(userId, System.currentTimeMillis());
         }
-        return true;
+
+        String clientIp = getClientIpFromRequest(request);
+        Bucket targetBucket = lastAccessMap.getOrDefault(clientIp, createBucket());
+
+        if (targetBucket.tryConsume(1)) {
+            lastAccessMap.put(clientIp, targetBucket);
+            return true;
+        }
+        throw new BaseException(BaseResponseStatus.TOO_MANY_REQUEST_ERROR);
     }
 
-    private String getUserIdFromRequest(HttpServletRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (!authentication.isAuthenticated())
-            throw new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR);
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        User user = userFindService.findByUserDetails(userDetails);
-        request.getRemoteHost();
-        request.getRemoteAddr();
-        request.getLocalAddr();
-        return String.valueOf(user.getId());
+    private String getClientIpFromRequest(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+
+    private Bucket createBucket() {
+        Refill refill = Refill.intervally(1, Duration.ofMillis(500)); // 0.5초당 1회 충전
+        Bandwidth limit = Bandwidth.classic(1, refill); // 최대 1회 가능
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
     }
 }
-
-
- */

--- a/src/main/java/blueclub/server/global/config/RateLimitingInterceptor.java
+++ b/src/main/java/blueclub/server/global/config/RateLimitingInterceptor.java
@@ -1,0 +1,54 @@
+package blueclub.server.global.config;
+
+import blueclub.server.global.response.BaseException;
+import blueclub.server.global.response.BaseResponseStatus;
+import blueclub.server.user.domain.User;
+import blueclub.server.user.service.UserFindService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+@RequiredArgsConstructor
+public class RateLimitingInterceptor implements HandlerInterceptor {
+
+    private final UserFindService userFindService;
+    private final Map<String, Long> lastAccessMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String userId = getUserIdFromRequest(request); // 요청에서 accountId를 추출하는 로직을 구현해야 합니다.
+        synchronized (this) {
+            long now = System.currentTimeMillis();
+            long lastAccess = lastAccessMap.getOrDefault(userId, 0L);
+            long elapsedTime = now - lastAccess;
+            if (elapsedTime < 1000) { // 1초?당 1회로 제한
+                Thread.sleep(1000 - elapsedTime);
+            }
+            lastAccessMap.put(userId, System.currentTimeMillis());
+        }
+        return true;
+    }
+
+    private String getUserIdFromRequest(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!authentication.isAuthenticated())
+            throw new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR);
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        User user = userFindService.findByUserDetails(userDetails);
+        request.getRemoteHost();
+        request.getRemoteAddr();
+        request.getLocalAddr();
+        return String.valueOf(user.getId());
+    }
+}
+
+
+ */

--- a/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
+++ b/src/main/java/blueclub/server/global/response/BaseResponseStatus.java
@@ -34,6 +34,7 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     INVALID_FILE(HttpStatus.BAD_REQUEST, "REQUEST_ERROR_004", "잘못된 File 형식입니다."),
     INVALID_AUTHORIZATION(HttpStatus.FORBIDDEN, "REQUEST_ERROR_005", "비정상적인 접근입니다."),
     INVALID_ENUM(HttpStatus.BAD_REQUEST, "REQUEST_ERROR_006", "변경할 수 없는 ENUM type 입니다."),
+    TOO_MANY_REQUEST_ERROR(HttpStatus.TOO_MANY_REQUESTS, "REQUEST_ERROR_007", "요청이 너무 잦습니다. 잠시 후 다시 시도해주세요."),
 
     // Auth
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_001", "이메일 형식이 올바르지 않습니다."),

--- a/src/main/java/blueclub/server/user/domain/Job.java
+++ b/src/main/java/blueclub/server/user/domain/Job.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum Job {
     CADDY("GOLF_CADDY", "골프캐디"),
     RIDER("DELIVERY_RIDER", "배달라이더"),
-    DAYWORKER("DAYWORKER", "일용직노동자");
+    DAYWORKER("DAYWORKER", "일용직근로자");
 
     private final String key;
     private final String title;

--- a/src/test/java/blueclub/server/auth/config/TestRateLimitingInterceptor.java
+++ b/src/test/java/blueclub/server/auth/config/TestRateLimitingInterceptor.java
@@ -1,0 +1,44 @@
+package blueclub.server.auth.config;
+
+import blueclub.server.global.response.BaseException;
+import blueclub.server.global.response.BaseResponseStatus;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TestRateLimitingInterceptor implements HandlerInterceptor {
+
+    private final Map<String, Bucket> lastAccessMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String clientIp = getClientIpFromRequest(request);
+        Bucket targetBucket = lastAccessMap.getOrDefault(clientIp, createBucket());
+
+        if (targetBucket.tryConsume(1)) {
+            lastAccessMap.put(clientIp, targetBucket);
+            return true;
+        }
+        throw new BaseException(BaseResponseStatus.TOO_MANY_REQUEST_ERROR);
+    }
+
+    private String getClientIpFromRequest(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+
+    private Bucket createBucket() {
+        Refill refill = Refill.intervally(1, Duration.ofMillis(10)); // 1밀리초당 1회 충전
+        Bandwidth limit = Bandwidth.classic(1, refill); // 최대 1회 가능
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+}
+

--- a/src/test/java/blueclub/server/auth/config/TestWebConfig.java
+++ b/src/test/java/blueclub/server/auth/config/TestWebConfig.java
@@ -1,0 +1,24 @@
+package blueclub.server.auth.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@TestConfiguration
+public class TestWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://blueclubserver.shop", "https://www.blueclubserver.shop", "http://localhost:8080")
+                .allowedMethods("GET", "POST", "DELETE", "PATCH", "PUT", "OPTIONS")
+                .maxAge(3000);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TestRateLimitingInterceptor());
+    }
+}
+

--- a/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/blueclub/server/diary/controller/DiaryControllerTest.java
@@ -52,7 +52,7 @@ public class DiaryControllerTest extends ControllerTest {
     private static final String JOB = "job";
     private static final String CADDY = "골프 캐디";
     private static final String RIDER = "배달 라이더";
-    private static final String DAYWORKER = "일용직 노동자";
+    private static final String DAYWORKER = "일용직 근로자";
     private static final String DATE = "date";
     private static final String TARGET_DATE = "2024-01-25";
 
@@ -238,7 +238,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("근무 일지 수정 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                                    parameterWithName("job").description("[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 근로자)")
                                             )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
@@ -300,7 +300,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("근무 일지 수정 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                                    parameterWithName("job").description("[필수] 직업명 (골프 캐디, 배달 라이더, 일용직 근로자)")
                                             )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
@@ -348,7 +348,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)")
                                             )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
@@ -401,7 +401,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)")
                                             )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
@@ -429,7 +429,7 @@ public class DiaryControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("일용직 노동자의 근무 일지 상세조회에 성공한다")
+        @DisplayName("일용직 근로자의 근무 일지 상세조회에 성공한다")
         void getDayworkerDiaryDetailsSuccess() throws Exception {
             // given
             doReturn(getDayworkerDiaryDetailsResponse())
@@ -454,7 +454,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)")
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)")
                                             )
                                             .pathParameters(
                                                     parameterWithName("diaryId").description("근무 일지 ID")
@@ -514,7 +514,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("날짜로 근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"),
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)"),
                                                     parameterWithName("date").description("날짜 // 형식 : yyyy-mm-dd")
                                             )
                                             .responseFields(
@@ -566,7 +566,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("날짜로 근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"),
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)"),
                                                     parameterWithName("date").description("날짜 // 형식 : yyyy-mm-dd")
                                             )
                                             .responseFields(
@@ -592,7 +592,7 @@ public class DiaryControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("일용직 노동자의 날짜로 근무 일지 상세조회에 성공한다")
+        @DisplayName("일용직 근로자의 날짜로 근무 일지 상세조회에 성공한다")
         void getDayworkerDiaryDetailsSuccess() throws Exception {
             // given
             doReturn(getDayworkerDiaryDetailsResponse())
@@ -617,7 +617,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("날짜로 근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"),
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)"),
                                                     parameterWithName("date").description("날짜 // 형식 : yyyy-mm-dd")
                                             )
                                             .responseFields(
@@ -669,7 +669,7 @@ public class DiaryControllerTest extends ControllerTest {
                                             .tag("Diary API")
                                             .summary("날짜로 근무 일지 상세조회 API")
                                             .queryParameters(
-                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 노동자)"),
+                                                    parameterWithName("job").description("직업명 (골프 캐디, 배달 라이더, 일용직 근로자)"),
                                                     parameterWithName("date").description("날짜 // 형식 : yyyy-mm-dd")
                                             )
                                             .responseFields(
@@ -768,7 +768,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.monthlyRecord[].date").type(STRING).description("근무 날짜"),
                                                     fieldWithPath("result.monthlyRecord[].worktype").type(STRING).description("근무 형태"),
                                                     fieldWithPath("result.monthlyRecord[].income").type(NUMBER).description("[DEFAULT 0] 총 수입"),
-                                                    fieldWithPath("result.monthlyRecord[].cases").type(NUMBER).description("[DEFAULT NULL] 총 건수 // 휴무, 일용직 노동자일 때 TYPE : NULL")
+                                                    fieldWithPath("result.monthlyRecord[].cases").type(NUMBER).description("[DEFAULT NULL] 총 건수 // 휴무, 일용직 근로자일 때 TYPE : NULL")
                                             )
                                             .responseSchema(Schema.schema("GetMonthlyListResponse"))
                                             .build()
@@ -866,7 +866,7 @@ public class DiaryControllerTest extends ControllerTest {
                                                     fieldWithPath("result.workAt").type(STRING).description("근무 날짜"),
                                                     fieldWithPath("result.rank").type(STRING).description("근무 순위"),
                                                     fieldWithPath("result.income").type(NUMBER).description("총 수입"),
-                                                    fieldWithPath("result.cases").type(NUMBER).description("[DEFAULT NULL] 총 건수 // 일용직 노동자일 때 TYPE : NULL")
+                                                    fieldWithPath("result.cases").type(NUMBER).description("[DEFAULT NULL] 총 건수 // 일용직 근로자일 때 TYPE : NULL")
                                             )
                                             .responseSchema(Schema.schema("GetBoastDiaryResponse"))
                                             .build()
@@ -875,7 +875,7 @@ public class DiaryControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("일용직 노동자의 자랑하기 상세조회에 성공한다")
+        @DisplayName("일용직 근로자의 자랑하기 상세조회에 성공한다")
         void getDayworkerBoastDiarySuccess() throws Exception {
             // given
             doReturn(getDayworkerBoastDiaryResponse())

--- a/src/test/java/blueclub/server/global/ControllerTest.java
+++ b/src/test/java/blueclub/server/global/ControllerTest.java
@@ -1,11 +1,14 @@
 package blueclub.server.global;
 
 import blueclub.server.auth.config.TestSecurityConfig;
+import blueclub.server.auth.config.TestWebConfig;
+import blueclub.server.auth.config.WebConfig;
 import blueclub.server.auth.controller.AuthController;
 import blueclub.server.auth.service.AuthService;
 import blueclub.server.diary.controller.DiaryController;
 import blueclub.server.diary.service.DiaryService;
 import blueclub.server.file.service.FileService;
+import blueclub.server.global.infra.ElasticBeanstalkHealthCheck;
 import blueclub.server.monthlyGoal.controller.MonthlyGoalController;
 import blueclub.server.monthlyGoal.service.MonthlyGoalService;
 import blueclub.server.notice.controller.NoticeController;
@@ -22,6 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -41,10 +46,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         MonthlyGoalController.class,
         NoticeController.class,
         ReminderController.class,
-        FileController.class
-})
+        FileController.class,
+        ElasticBeanstalkHealthCheck.class
+}, excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class))
 @ExtendWith(RestDocumentationExtension.class)
-@Import(TestSecurityConfig.class)
+@Import({
+        TestSecurityConfig.class,
+        TestWebConfig.class
+})
 @AutoConfigureRestDocs
 public class ControllerTest {
     @Autowired

--- a/src/test/java/blueclub/server/global/controller/GlobalExceptionControllerTest.java
+++ b/src/test/java/blueclub/server/global/controller/GlobalExceptionControllerTest.java
@@ -1,0 +1,78 @@
+package blueclub.server.global.controller;
+
+import blueclub.server.global.ControllerTest;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Global Exception [Controller Layer] -> Global Exception 테스트")
+public class GlobalExceptionControllerTest extends ControllerTest {
+
+    @Nested
+    @DisplayName("Global Exception [GET /health]")
+    class tooManyRequest {
+        private static final String BASE_URL = "/health";
+
+        @Test
+        @DisplayName("API를 0.5초당 2회 이상 호출 시도 시 예외를 반환한다")
+        void throwExceptionByTooManyRequest() throws Exception {
+            // given
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .get(BASE_URL);
+
+            // then
+            Thread first = new Thread(() -> {
+                try {
+                    mockMvc.perform(requestBuilder)
+                            .andExpect(status().isOk());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+
+            Thread second = new Thread(() -> {
+                try {
+                    mockMvc.perform(requestBuilder)
+                            .andExpect(status().isTooManyRequests())
+                            .andDo(document(
+                                    "TooManyRequests",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    resource(
+                                            ResourceSnippetParameters.builder()
+                                                    .tag("Global Exception")
+                                                    .summary("지나치게 잦은 요청(0.5초당 1회 초과) 시 예외")
+                                                    .responseFields(
+                                                            fieldWithPath("code").type(STRING).description("커스텀 상태 코드"),
+                                                            fieldWithPath("message").type(STRING).description("커스텀 상태 메시지"),
+                                                            fieldWithPath("result").type(NULL).description("null 반환")
+                                                    )
+                                                    .responseSchema(Schema.schema("BaseResponse"))
+                                                    .build()
+                                    )
+                            ));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+
+            first.start();
+            Thread.sleep(0, 1);
+            second.start();
+        }
+    }
+}


### PR DESCRIPTION
## Summary 📌
- API가 단시간에 과도한 호출 시 서버 다운되는 문제 발생으로 인한 정책 적용
  - 사용자 기준, IP 기준, 클라이언트 고유식별자 기준 등 고려 >> 회의 후 IP 기준으로 결정
## Describe your changes 📝
- IP 기반 rate limit 적용
- Dayworker value 수정 (일용직 노동자 >> 일용직 근로자)
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #121 